### PR TITLE
fix(profile): make gameName#tagLine responsive for long names

### DIFF
--- a/src/components/league/Profile.js
+++ b/src/components/league/Profile.js
@@ -23,8 +23,8 @@ const Profile = ({ accountData, profileData }) => {
 				) : (
 					<div className="bg-gray-600 rounded-full w-20 h-20"></div>
 				)}
-				<div className="ml-6">
-					<h1 className="text-[#979aa0] text-xl sm:text-3xl font-semibold">
+				<div className="ml-6 w-full">
+					<h1 className="text-[#979aa0] text-lg sm:text-2xl font-semibold break-words sm:break-all w-full">
 						{`${accountData.gameName}#${accountData.tagLine}`}
 					</h1>
 				</div>


### PR DESCRIPTION
- Added break-words and break-all classes to ensure long names wrap correctly
- Adjusted text size for better readability on different screen sizes
- Applied w-full to ensure the gameName#tagLine container takes up available width