### PR TITLE
feat(ranked): improve ranked section styling and add gold glow around…

### DIFF
--- a/src/components/league/RankedInfo.js
+++ b/src/components/league/RankedInfo.js
@@ -18,14 +18,18 @@ const RankedInfo = ({ rankedData }) => {
 			const winrate = (data.wins / (data.wins + data.losses)) * 100;
 
 			return (
-				<div className="overflow-hidden p-6 mb-4">
-					<h2 className="text-[#979aa0] text-lg font-semibold">
+				<div className="p-4 mb-6 rounded-lg shadow-md bg-[#13151b] border border-transparent relative overflow-hidden">
+					{/* Added gold glow only around the border */}
+					<div className="absolute inset-0 rounded-lg border border-transparent pointer-events-none shadow-[0_0_20px_rgba(255,215,0,0.8)]"></div>
+
+					<h2 className="text-[#e5e7eb] text-xl font-bold mb-2 relative z-10">
 						{getQueueName(queueType)}
 					</h2>
-					<div className="flex items-center mt-4">
+
+					<div className="flex items-center mt-4 relative z-10">
 						<Image src={rankedIcon} alt="Ranked Icon" width={75} height={75} />
 						<div className="ml-4">
-							<h3 className="text-[#979aa0] text-lg font-semibold">
+							<h3 className="text-[#e5e7eb] text-lg font-semibold">
 								{data.tier} {data.rank}
 							</h3>
 							<p className="text-gray-400 text-sm">{data.leaguePoints} LP</p>
@@ -35,7 +39,7 @@ const RankedInfo = ({ rankedData }) => {
 							<div className="bg-gray-600 h-2 mt-1 rounded">
 								<div
 									className="bg-green-400 h-2 rounded"
-									style={{ width: `${clampedProgressBarWidth}%` }} // Adjusted width calculation
+									style={{ width: `${clampedProgressBarWidth}%` }}
 								></div>
 							</div>
 						</div>
@@ -44,11 +48,15 @@ const RankedInfo = ({ rankedData }) => {
 			);
 		} else {
 			return (
-				<div className="overflow-hidden p-6 mb-4">
-					<h2 className="text-[#979aa0] text-lg font-semibold">
+				<div className="p-4 mb-6 rounded-lg shadow-md bg-[#13151b] border border-transparent relative overflow-hidden">
+					{/* Added gold glow only around the border */}
+					<div className="absolute inset-0 rounded-lg border border-transparent pointer-events-none shadow-[0_0_20px_rgba(255,215,0,0.8)]"></div>
+
+					<h2 className="text-[#e5e7eb] text-xl font-bold mb-2 relative z-10">
 						{getQueueName(queueType)}
 					</h2>
-					<p className="text-gray-400 text-sm">Unranked</p>
+
+					<p className="text-gray-400 text-sm relative z-10">Unranked</p>
 				</div>
 			);
 		}
@@ -66,7 +74,8 @@ const RankedInfo = ({ rankedData }) => {
 	};
 
 	return (
-		<div className="bg-[#13151b] rounded-lg overflow-hidden shadow-lg p-6">
+		<div className="space-y-6">
+			{/* Separate boxes for Ranked Solo/Duo and Ranked Flex */}
 			{renderRankedItem(soloRankedData, "RANKED_SOLO_5x5")}
 			{renderRankedItem(flexRankedData, "RANKED_FLEX_SR")}
 		</div>


### PR DESCRIPTION
… border

- Enhanced "Ranked Solo/Duo" and "Ranked Flex" titles to be more prominent with larger font, brighter color, and bold weight
- Reduced padding inside ranked boxes for a more compact look
- Added separate boxes for "Ranked Solo/Duo" and "Ranked Flex" with spacing between them
- Applied a gold glow effect around the border of each ranked box, keeping the original background color intact