### PR TITLE
ClutchGG v1.5.0 Release

### DIFF
--- a/src/components/league/MatchHistory.js
+++ b/src/components/league/MatchHistory.js
@@ -126,7 +126,6 @@ const MatchHistory = ({
 			{filteredMatches.map((match, index) => {
 				const participants = match.info.participants;
 
-				// Calculate CS/Min for each participant and find the one with the highest CS/Min
 				let maxCsPerMin = 0;
 				let maxCsPerMinParticipant = null;
 
@@ -272,10 +271,11 @@ const MatchHistory = ({
 					>
 						<div className="absolute top-4 left-4 flex items-start">
 							<div className="flex items-center mr-4">
+								{/* Champion Icon with responsive sizing */}
 								<Image
 									src={`https://raw.communitydragon.org/latest/plugins/rcp-be-lol-game-data/global/default/v1/champion-icons/${currentPlayer.championId}.png`}
 									alt="Champion Icon"
-									className={`w-16 h-16 rounded-full border-2 ${getOutcomeClass(
+									className={`sm:w-12 sm:h-12 w-16 h-16 rounded-full border-2 ${getOutcomeClass(
 										currentPlayer.win,
 										isRemake
 									)}`}
@@ -289,7 +289,7 @@ const MatchHistory = ({
 										className={`font-semibold mr-2 ${getOutcomeClass(
 											currentPlayer.win,
 											isRemake
-										)}`}
+										)} sm:text-sm md:text-base lg:text-lg`}
 									>
 										{isRemake
 											? "Remake"
@@ -322,7 +322,9 @@ const MatchHistory = ({
 								</div>
 								<div className="flex">
 									<div className="flex flex-col mr-8">
-										<p className="text-lg font-bold">{kda} KDA</p>
+										<p className="sm:text-sm md:text-base lg:text-lg font-bold">
+											{kda} KDA
+										</p>
 										<p className="text-md">
 											{currentPlayer.kills}/{currentPlayer.deaths}/
 											{currentPlayer.assists}
@@ -330,12 +332,16 @@ const MatchHistory = ({
 									</div>
 									{match.info.queueId === 1700 ? (
 										<div className="flex flex-col">
-											<p className="text-lg font-bold">{dpm} DPM</p>
+											<p className="sm:text-sm md:text-base lg:text-lg font-bold">
+												{dpm} DPM
+											</p>
 											<p className="text-md">{goldEarned} Gold</p>
 										</div>
 									) : (
 										<div className="flex flex-col">
-											<p className="text-lg font-bold">{csPerMin} CS/Min</p>
+											<p className="sm:text-sm md:text-base lg:text-lg font-bold">
+												{csPerMin} CS/Min
+											</p>
 											<p className="text-md">{cs} CS</p>
 										</div>
 									)}
@@ -346,6 +352,7 @@ const MatchHistory = ({
 						<div className="h-24"></div>
 						<div className="absolute top-16 right-72 flex items-center justify-center">
 							<div className="flex flex-col items-center mr-2 gap-2">
+								{/* Responsive summoner spell icons */}
 								{[currentPlayer.summoner1Id, currentPlayer.summoner2Id].map(
 									(spellId, idx) => (
 										<Image
@@ -354,12 +361,13 @@ const MatchHistory = ({
 											alt={`Summoner Spell ${idx + 1}`}
 											width={28}
 											height={28}
-											className="w-8 h-8 rounded-full border border-gray-700"
+											className="sm:w-6 sm:h-6 w-8 h-8 rounded-full border border-gray-700"
 										/>
 									)
 								)}
 							</div>
 							<div className="grid grid-cols-4 gap-2">
+								{/* Responsive item icons */}
 								{items.slice(0, 3).map((itemId, idx) => (
 									<div key={idx} className="flex items-center">
 										{itemId > 0 ? (
@@ -368,7 +376,7 @@ const MatchHistory = ({
 												alt="Item"
 												width={28}
 												height={28}
-												className="w-8 h-8 rounded-lg border border-gray-700"
+												className="sm:w-6 sm:h-6 w-8 h-8 rounded-lg border border-gray-700"
 											/>
 										) : (
 											<Image
@@ -376,7 +384,7 @@ const MatchHistory = ({
 												alt="No item"
 												width={28}
 												height={28}
-												className="w-8 h-8 rounded-lg border border-gray-700"
+												className="sm:w-6 sm:h-6 w-8 h-8 rounded-lg border border-gray-700"
 											/>
 										)}
 									</div>
@@ -388,7 +396,7 @@ const MatchHistory = ({
 											alt="Ward"
 											width={28}
 											height={28}
-											className="w-8 h-8 rounded-lg border border-gray-700"
+											className="sm:w-6 sm:h-6 w-8 h-8 rounded-lg border border-gray-700"
 										/>
 									</div>
 								) : (
@@ -397,7 +405,7 @@ const MatchHistory = ({
 										alt="No ward"
 										width={28}
 										height={28}
-										className="w-8 h-8 rounded-lg border border-gray-700"
+										className="sm:w-6 sm:h-6 w-8 h-8 rounded-lg border border-gray-700"
 									/>
 								)}
 								{items.slice(3, 6).map((itemId, idx) => (
@@ -408,7 +416,7 @@ const MatchHistory = ({
 												alt="Item"
 												width={28}
 												height={28}
-												className="w-8 h-8 rounded-lg border border-gray-700"
+												className="sm:w-6 sm:h-6 w-8 h-8 rounded-lg border border-gray-700"
 											/>
 										) : (
 											<Image
@@ -416,14 +424,15 @@ const MatchHistory = ({
 												alt="No item"
 												width={28}
 												height={28}
-												className="w-8 h-8 rounded-lg border border-gray-700"
+												className="sm:w-6 sm:h-6 w-8 h-8 rounded-lg border border-gray-700"
 											/>
 										)}
 									</div>
 								))}
 							</div>
 						</div>
-						{match.info.queueId === 1700 ? ( // Check if it's arena mode
+
+						{match.info.queueId === 1700 ? (
 							<div className="absolute top-6 right-16 flex">
 								<div className="grid grid-cols-2 gap-2">
 									{augments.map((augmentId, idx) => (
@@ -449,7 +458,7 @@ const MatchHistory = ({
 												alt="Participant Champion"
 												width={24}
 												height={24}
-												className="w-6 h-6 rounded-full border border-gray-700 ml-1"
+												className="sm:w-6 sm:h-6 w-6 h-6 rounded-full border border-gray-700 ml-1"
 											/>
 											<p
 												className="text-sm truncate"
@@ -476,7 +485,7 @@ const MatchHistory = ({
 												alt="Participant Champion"
 												width={24}
 												height={24}
-												className="w-6 h-6 rounded-full border border-gray-700 mr-1"
+												className="sm:w-6 sm:h-6 w-6 h-6 rounded-full border border-gray-700 mr-1"
 											/>
 											<p
 												className="text-sm truncate"

--- a/src/components/league/Profile.js
+++ b/src/components/league/Profile.js
@@ -4,27 +4,33 @@ const Profile = ({ accountData, profileData }) => {
 	const profileIcon = `https://raw.communitydragon.org/latest/plugins/rcp-be-lol-game-data/global/default/v1/profile-icons/${profileData.profileIconId}.jpg`;
 
 	return (
-		<div className="bg-[#13151b] rounded-lg overflow-hidden shadow-lg p-6">
-			<div className="flex items-center">
+		<div className="bg-[#13151b] rounded-lg overflow-hidden shadow-[0_0_20px_rgba(255,215,0,0.8)] p-6 border-4 border-[#13151b]">
+			<div className="flex items-center relative">
 				{profileData?.profileIconId ? (
 					<div className="relative">
-						<div className="rounded-full border-4 border-[#979aa0] overflow-hidden w-20 h-20">
-							<Image
-								src={profileIcon}
-								alt="Player Icon"
-								layout="fill"
-								objectFit="cover"
-							/>
+						{/* Profile Icon with gold glow effect */}
+						<div className="rounded-lg overflow-hidden w-20 h-20 border-4 border-transparent bg-gradient-to-r from-yellow-400 to-yellow-600 p-1 shadow-[0_0_15px_rgba(255,215,0,0.6)]">
+							<div className="rounded-lg overflow-hidden w-full h-full">
+								<Image
+									src={profileIcon}
+									alt="Player Icon"
+									layout="fill"
+									objectFit="cover"
+									className="rounded-lg"
+								/>
+							</div>
 						</div>
-						<div className="absolute bottom-0 left-5 bg-gray-800 text-[#979aa0] text-xs font-semibold py-1 px-2 rounded-full">
+
+						{/* Smaller, neat Level Badge with gold glow */}
+						<div className="absolute -bottom-2 left-1/2 transform -translate-x-1/2 bg-[#ffd700] text-white text-xs font-medium py-0.5 px-2 rounded-full shadow-[0_0_10px_rgba(255,215,0,0.8)]">
 							{profileData?.summonerLevel}
 						</div>
 					</div>
 				) : (
-					<div className="bg-gray-600 rounded-full w-20 h-20"></div>
+					<div className="bg-gray-600 rounded-lg w-20 h-20"></div>
 				)}
 				<div className="ml-6 w-full">
-					<h1 className="text-[#979aa0] text-lg sm:text-2xl font-semibold break-words sm:break-all w-full">
+					<h1 className="text-[#979aa0] text-lg sm:text-2xl font-semibold break-words sm:break-all">
 						{`${accountData.gameName}#${accountData.tagLine}`}
 					</h1>
 				</div>

--- a/src/components/league/Profile.js
+++ b/src/components/league/Profile.js
@@ -23,8 +23,8 @@ const Profile = ({ accountData, profileData }) => {
 				) : (
 					<div className="bg-gray-600 rounded-full w-20 h-20"></div>
 				)}
-				<div className="ml-6">
-					<h1 className="text-[#979aa0] text-xl sm:text-3xl font-semibold">
+				<div className="ml-6 w-full">
+					<h1 className="text-[#979aa0] text-lg sm:text-2xl font-semibold break-words sm:break-all w-full">
 						{`${accountData.gameName}#${accountData.tagLine}`}
 					</h1>
 				</div>

--- a/src/components/league/RankedInfo.js
+++ b/src/components/league/RankedInfo.js
@@ -18,14 +18,18 @@ const RankedInfo = ({ rankedData }) => {
 			const winrate = (data.wins / (data.wins + data.losses)) * 100;
 
 			return (
-				<div className="overflow-hidden p-6 mb-4">
-					<h2 className="text-[#979aa0] text-lg font-semibold">
+				<div className="p-4 mb-6 rounded-lg shadow-md bg-[#13151b] border border-transparent relative overflow-hidden">
+					{/* Added gold glow only around the border */}
+					<div className="absolute inset-0 rounded-lg border border-transparent pointer-events-none shadow-[0_0_20px_rgba(255,215,0,0.8)]"></div>
+
+					<h2 className="text-[#e5e7eb] text-xl font-bold mb-2 relative z-10">
 						{getQueueName(queueType)}
 					</h2>
-					<div className="flex items-center mt-4">
+
+					<div className="flex items-center mt-4 relative z-10">
 						<Image src={rankedIcon} alt="Ranked Icon" width={75} height={75} />
 						<div className="ml-4">
-							<h3 className="text-[#979aa0] text-lg font-semibold">
+							<h3 className="text-[#e5e7eb] text-lg font-semibold">
 								{data.tier} {data.rank}
 							</h3>
 							<p className="text-gray-400 text-sm">{data.leaguePoints} LP</p>
@@ -35,7 +39,7 @@ const RankedInfo = ({ rankedData }) => {
 							<div className="bg-gray-600 h-2 mt-1 rounded">
 								<div
 									className="bg-green-400 h-2 rounded"
-									style={{ width: `${clampedProgressBarWidth}%` }} // Adjusted width calculation
+									style={{ width: `${clampedProgressBarWidth}%` }}
 								></div>
 							</div>
 						</div>
@@ -44,11 +48,15 @@ const RankedInfo = ({ rankedData }) => {
 			);
 		} else {
 			return (
-				<div className="overflow-hidden p-6 mb-4">
-					<h2 className="text-[#979aa0] text-lg font-semibold">
+				<div className="p-4 mb-6 rounded-lg shadow-md bg-[#13151b] border border-transparent relative overflow-hidden">
+					{/* Added gold glow only around the border */}
+					<div className="absolute inset-0 rounded-lg border border-transparent pointer-events-none shadow-[0_0_20px_rgba(255,215,0,0.8)]"></div>
+
+					<h2 className="text-[#e5e7eb] text-xl font-bold mb-2 relative z-10">
 						{getQueueName(queueType)}
 					</h2>
-					<p className="text-gray-400 text-sm">Unranked</p>
+
+					<p className="text-gray-400 text-sm relative z-10">Unranked</p>
 				</div>
 			);
 		}
@@ -66,7 +74,8 @@ const RankedInfo = ({ rankedData }) => {
 	};
 
 	return (
-		<div className="bg-[#13151b] rounded-lg overflow-hidden shadow-lg p-6">
+		<div className="space-y-6">
+			{/* Separate boxes for Ranked Solo/Duo and Ranked Flex */}
 			{renderRankedItem(soloRankedData, "RANKED_SOLO_5x5")}
 			{renderRankedItem(flexRankedData, "RANKED_FLEX_SR")}
 		</div>


### PR DESCRIPTION
## New Features & Enhancements:

- **Profile Section Improvements**:
  - Introduced a **gold glow effect** around the profile icon, level badge, and container for a more premium look.
  - Refined the overall profile appearance by adjusting the position of the level badge and maintaining the original border while applying the glowing effect.
  - Ensured **gameName#tagLine** is now responsive for long names, with proper text wrapping and sizing adjustments for better readability across screen sizes.

- **Responsiveness Updates**:
  - Made all icons (champions, items, summoner spells) and text responsive based on screen resolution using Tailwind utilities. This ensures a consistent layout across devices, especially on smaller screens where elements shrink appropriately.

- **Ranked Section Enhancements**:
  - Improved the design of the **Ranked Solo/Duo** and **Ranked Flex** sections with larger, brighter titles that stand out as the area’s heading.
  - Added a **gold glow effect** around the border of each ranked box to match the profile section.
  - Separated **Ranked Solo/Duo** and **Ranked Flex** into individual boxes with better spacing and reduced padding for a more compact and clean layout.

## Bug Fixes:
- Resolved issues with long game names being cut off in the profile section by ensuring **responsive text wrapping** and **adjusted container width** to handle various screen sizes.
