### PR TITLE
Fix DiscordBotBanner Sticky Positioning on Profile Page

### DIFF
--- a/src/app/league/profile/page.js
+++ b/src/app/league/profile/page.js
@@ -239,7 +239,7 @@ const ProfilePageContent = () => {
 							)}
 						</div>
 						{/* Show DiscordBotBanner only on medium and larger devices */}
-						<div className="hidden md:flex justify-center md:w-auto">
+						<div className="hidden md:flex md:sticky top-4 self-start justify-center z-50">
 							<DiscordBotBanner />
 						</div>
 					</div>


### PR DESCRIPTION
This PR adjusts the DiscordBotBanner container styling to ensure it remains sticky within its column on the profile page. By using Tailwind's sticky positioning along with proper alignment (top-4 and self-start), the banner now stays visible as users scroll without affecting its original placement.