### PR TITLE
Add Discord Support Button and Update Discord Links

### DIFF
--- a/src/components/Footer.js
+++ b/src/components/Footer.js
@@ -36,7 +36,7 @@ const Footer = () => {
 						<ul>
 							<li>
 								<Link
-									href="https://discord.gg/neeSSbRzrJ"
+									href="https://discord.gg/BeszQxTn9D"
 									className="text-sm hover:underline"
 								>
 									Discord

--- a/src/components/NavBar.js
+++ b/src/components/NavBar.js
@@ -5,7 +5,7 @@ import { usePathname, useSearchParams } from "next/navigation";
 import Image from "next/image";
 import Link from "next/link";
 import SearchBar from "@/components/SearchBar";
-import { FaCoffee } from "react-icons/fa";
+import { FaCoffee, FaDiscord } from "react-icons/fa"; // <-- added FaDiscord
 
 const NavBar = ({ isBannerVisible }) => {
 	const [isMenuOpen, setIsMenuOpen] = useState(false);
@@ -55,7 +55,7 @@ const NavBar = ({ isBannerVisible }) => {
 						<span className="ml-2 px-2 hidden sm:inline">Search</span>
 					</button>
 				)}
-				{/* Desktop Links */}
+				{/* Desktop Links (Left Aligned) */}
 				<div className="hidden md:flex items-center space-x-4">
 					<Link
 						href="/league/leaderboard"
@@ -73,6 +73,19 @@ const NavBar = ({ isBannerVisible }) => {
 						<span className="ml-2">Support Us</span>
 					</Link>
 				</div>
+			</div>
+
+			{/* Discord Button on the far right (Desktop Only) */}
+			<div className="hidden md:flex items-center">
+				<Link
+					href="https://discord.gg/BeszQxTn9D"
+					target="_blank"
+					rel="noopener noreferrer"
+					className="flex items-center px-3 py-2 bg-[#7289DA] text-white rounded-md font-bold hover:bg-[#677bc4]"
+				>
+					<FaDiscord className="w-5 h-5 mr-2" />
+					<span>Support</span>
+				</Link>
 			</div>
 
 			{/* Mobile Hamburger */}

--- a/src/components/league/NoProfileFound.js
+++ b/src/components/league/NoProfileFound.js
@@ -15,14 +15,14 @@ const NoProfileFound = () => {
 			<p className="text-xl text-white text-center">
 				<>
 					Unable to find a profile. Please ensure the correct region and Riot ID
-					are entered. If this keeps happening, please open an issue on{" "}
+					are entered. If this keeps happening, please open an issue on our{" "}
 					<Link
-						href="https://github.com/danblock97/clutch-gg/issues"
+						href="https://discord.gg/BeszQxTn9D"
 						target="_blank"
 						rel="noopener noreferrer"
 						className="text-blue-500"
 					>
-						GitHub
+						Discord Support Server
 					</Link>
 					.
 				</>


### PR DESCRIPTION
This PR adds a new Discord support button with the Discord logo on the far right of the NavBar for desktop users and updates the Discord link in both the Footer and NoProfileFound components to use "https://discord.gg/BeszQxTn9D". These changes ensure consistent and correct support server links across the app.