### PR TITLE
Update PortalTooltip Styling to Use Gradient Background

### DIFF
--- a/src/components/league/LiveGame.js
+++ b/src/components/league/LiveGame.js
@@ -141,7 +141,7 @@ function PortalTooltip({ children, top, left, flipAbove }) {
 			className={`
         absolute z-[9999] 
         px-3 py-2 
-        bg-gray-800 text-white 
+        bg-gradient-to-br from-[#232337] to-[#1b1b2d] text-white 
         rounded-md shadow-lg
         text-xs sm:text-sm
         transform -translate-x-1/2

--- a/src/components/league/MatchDetails.js
+++ b/src/components/league/MatchDetails.js
@@ -433,7 +433,7 @@ function PortalTooltip({ top, left, flipAbove, children }) {
 			className={`
         absolute z-[9999]
         px-3 py-2
-        bg-gray-800 text-white
+        bg-gradient-to-br from-[#232337] to-[#1b1b2d] text-white
         rounded-md shadow-lg
         text-xs sm:text-sm
         transform -translate-x-1/2


### PR DESCRIPTION
This PR updates the PortalTooltip component styling in both LiveGame.js and MatchDetails.js. The static bg-gray-800 has been replaced with a gradient background (from #232337 to #1b1b2d) to align with the updated design guidelines and improve visual consistency.