### PR TITLE
Simplify ChampionMastery Tooltip

### DIFF
--- a/src/components/league/ChampionMastery.js
+++ b/src/components/league/ChampionMastery.js
@@ -57,7 +57,7 @@ const ChampionMastery = ({ championMasteryData }) => {
                 transition-colors
                 duration-200
               "
-							title={`Champion: ${mastery.championName}, Mastery Level: ${mastery.championLevel}`}
+							title={`Mastery Level: ${mastery.championLevel}`}
 						>
 							{/* Champion Icon */}
 							<div className="relative w-[60px] h-[60px] rounded-full overflow-hidden">


### PR DESCRIPTION
This change updates the tooltip title in ChampionMastery.js to only display the mastery level instead of including both the champion name and mastery level, reducing redundancy and improving clarity.