### PR TITLE
CL-2: fix(Tag): Adjust tooltip positioning and improve class formatting

### DIFF
--- a/src/components/league/Tag.js
+++ b/src/components/league/Tag.js
@@ -4,27 +4,28 @@ const Tag = ({ text, hoverText, color, icon }) => {
 	return (
 		<div className="relative group">
 			<div
-				className={`px-1 py-1 text-xs font-semibold rounded-md bg-opacity-80 ${color} 
-                shadow-md 
-                relative z-10 
-                transition-transform transform 
-                group-hover:scale-105 
-                flex items-center space-x-1
-                max-w-[100px] truncate`}
+				className={`px-1 py-1 text-xs font-semibold rounded-md bg-opacity-80 ${color}
+                  shadow-md
+                  relative z-10
+                  transition-transform transform
+                  group-hover:scale-105
+                  flex items-center space-x-1
+                  max-w-[100px] truncate`}
 			>
 				{icon && <span className="relative z-20 text-xs">{icon}</span>}
 				<span className="relative z-20 truncate min-w-0">{text}</span>
 			</div>
 
-			{/* Tooltip on Hover */}
+			{/* Tooltip on Hover - Adjusted positioning */}
 			<div
-				className="absolute bottom-full left-1/2 transform -translate-x-1/2 mb-2
+				className="absolute bottom-full left-0 mb-2
                            hidden group-hover:block
                            bg-gray-800 text-white text-xs rounded px-3 py-2
                            shadow-lg
-                           before:absolute before:top-full before:left-1/2 before:-translate-x-1/2 before:border-4 before:border-transparent before:border-t-black
+                           before:absolute before:top-full before:left-4 before:border-4 before:border-transparent before:border-t-gray-800
                            z-30
-                           whitespace-nowrap"
+                           whitespace-nowrap
+                           min-w-[150px] max-w-[250px]"
 			>
 				<span className="font-bold">{text}</span>
 				<br />


### PR DESCRIPTION
This pull request includes a few changes to the tooltip positioning and styling in the `Tag` component to improve its appearance and readability.

Styling and positioning adjustments:

* [`src/components/league/Tag.js`](diffhunk://#diff-fcf5d462c910b76103616897f14450bd7186930be5f1c2a68860328fa820d7f2L19-R28): Adjusted the tooltip positioning from `left-1/2` to `left-0` and modified the before pseudo-element's position and color. Added minimum and maximum width constraints to the tooltip for better readability.