### PR TITLE
chore(vercel): add configuration to disable deployment

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -1,0 +1,5 @@
+{
+  "git": {
+    "deploymentEnabled": false
+  }
+}


### PR DESCRIPTION
This pull request includes a small change to the `vercel.json` file. The change disables git-based deployments by setting `deploymentEnabled` to `false`.

* [`vercel.json`](diffhunk://#diff-a3265310f552fb66876e8bfe8809737e59e5ba946bdf39138b44d9baf4e21240R1-R5): Added a configuration to disable git-based deployments.