### PR TITLE
fix(MatchHistory): conditionally render tags based on queueId

### DIFF
--- a/src/components/league/MatchHistory.js
+++ b/src/components/league/MatchHistory.js
@@ -819,9 +819,11 @@ const MatchHistory = ({
 												))}
 											</div>
 										</div>
-										<div className="flex flex-wrap justify-start space-x-2">
-											{tags.slice(0, maxTagsToShow)}
-										</div>
+										{match.info.queueId !== 1700 && (
+											<div className="flex flex-wrap justify-start space-x-2">
+												{tags.slice(0, maxTagsToShow)}
+											</div>
+										)}
 										{match.info.queueId === 1700 ? (
 											<div className="absolute top-6 right-16 flex">
 												<div className="grid grid-cols-2 gap-2">


### PR DESCRIPTION
This pull request includes a small change to the `MatchHistory` component in the `src/components/league/MatchHistory.js` file. The change adds a conditional rendering check for the `queueId` property of the `match.info` object. If `queueId` is not equal to 1700, a div containing tags is rendered.