### PR TITLE
fix(rankHistory): Clean LP text before parsing

### DIFF
--- a/src/app/api/league/rankHistory/route.js
+++ b/src/app/api/league/rankHistory/route.js
@@ -6,240 +6,250 @@ const CACHE = new Map();
 const CACHE_TTL = 24 * 60 * 60 * 1000;
 
 export async function GET(req) {
-    const { searchParams } = new URL(req.url);
-    const gameName = searchParams.get("gameName");
-    const tagLine = searchParams.get("tagLine");
-    const region = searchParams.get("region").toLowerCase();
-    const forceRefresh = searchParams.get("refresh") === "true";
+	const { searchParams } = new URL(req.url);
+	const gameName = searchParams.get("gameName");
+	const tagLine = searchParams.get("tagLine");
+	const region = searchParams.get("region").toLowerCase();
+	const forceRefresh = searchParams.get("refresh") === "true";
 
-    if (!gameName || !tagLine || !region) {
-        return NextResponse.json(
-            { error: "Missing required query parameters" },
-            { status: 400 }
-        );
-    }
+	if (!gameName || !tagLine || !region) {
+		return NextResponse.json(
+			{ error: "Missing required query parameters" },
+			{ status: 400 }
+		);
+	}
 
-    const cacheKey = `rankHistory_${gameName}_${tagLine}_${region}`;
+	const cacheKey = `rankHistory_${gameName}_${tagLine}_${region}`;
 
-    if (!forceRefresh && CACHE.has(cacheKey)) {
-        const cachedData = CACHE.get(cacheKey);
+	if (!forceRefresh && CACHE.has(cacheKey)) {
+		const cachedData = CACHE.get(cacheKey);
 
-        if (Date.now() < cachedData.expiresAt) {
-            console.log(`Using cached rank history for ${gameName}#${tagLine}`);
+		if (Date.now() < cachedData.expiresAt) {
+			console.log(`Using cached rank history for ${gameName}#${tagLine}`);
 
-            return NextResponse.json(cachedData.data, {
-                status: 200,
-                headers: {
-                    "Cache-Control": "public, max-age=86400",
-                    "X-Cache": "HIT",
-                    "X-Cache-Expires": new Date(cachedData.expiresAt).toUTCString()
-                }
-            });
-        } else {
-            CACHE.delete(cacheKey);
-        }
-    }
+			return NextResponse.json(cachedData.data, {
+				status: 200,
+				headers: {
+					"Cache-Control": "public, max-age=86400",
+					"X-Cache": "HIT",
+					"X-Cache-Expires": new Date(cachedData.expiresAt).toUTCString(),
+				},
+			});
+		} else {
+			CACHE.delete(cacheKey);
+		}
+	}
 
-    try {
-        const opggRegionMap = {
-            euw1: "euw",
-            na1: "na",
-            kr: "kr",
-            eun1: "eune",
-            br1: "br",
-            jp1: "jp",
-            la1: "lan",
-            la2: "las",
-            oc1: "oce",
-            ru: "ru",
-            tr1: "tr",
-        };
+	try {
+		const opggRegionMap = {
+			euw1: "euw",
+			na1: "na",
+			kr: "kr",
+			eun1: "eune",
+			br1: "br",
+			jp1: "jp",
+			la1: "lan",
+			la2: "las",
+			oc1: "oce",
+			ru: "ru",
+			tr1: "tr",
+		};
 
-        const opggRegion = opggRegionMap[region.toLowerCase()] || region;
+		const opggRegion = opggRegionMap[region.toLowerCase()] || region;
 
-        const opggUrl = `https://${opggRegion}.op.gg/summoners/${opggRegion}/${encodeURIComponent(gameName)}-${encodeURIComponent(tagLine)}`;
+		const opggUrl = `https://${opggRegion}.op.gg/summoners/${opggRegion}/${encodeURIComponent(
+			gameName
+		)}-${encodeURIComponent(tagLine)}`;
 
-        console.log(`Fetching data from: ${opggUrl}`);
+		console.log(`Fetching data from: ${opggUrl}`);
 
-        const response = await axios.get(opggUrl, {
-            headers: {
-                'User-Agent': 'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/123.0.0.0 Safari/537.36',
-                'Accept': 'text/html,application/xhtml+xml,application/xml;q=0.9,image/avif,image/webp,image/apng,*/*;q=0.8',
-                'Accept-Language': 'en-US,en;q=0.9',
-                'Referer': 'https://op.gg/',
-                'Cache-Control': 'no-cache',
-                'Pragma': 'no-cache'
-            },
-            timeout: 10000
-        });
+		const response = await axios.get(opggUrl, {
+			headers: {
+				"User-Agent":
+					"Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/123.0.0.0 Safari/537.36",
+				Accept:
+					"text/html,application/xhtml+xml,application/xml;q=0.9,image/avif,image/webp,image/apng,*/*;q=0.8",
+				"Accept-Language": "en-US,en;q=0.9",
+				Referer: "https://op.gg/",
+				"Cache-Control": "no-cache",
+				Pragma: "no-cache",
+			},
+			timeout: 10000,
+		});
 
-        const html = response.data;
-        const $ = cheerio.load(html);
+		const html = response.data;
+		const $ = cheerio.load(html);
 
-        const rankHistory = [];
+		const rankHistory = [];
 
-// Filter for the table with the caption "Ranked Solo/Duo"
-        const rankedSoloDuoTable = $('table').filter((i, table) => {
-            return $(table).find('caption').text().trim() === 'Ranked Solo/Duo';
-        });
+		// Filter for the table with the caption "Ranked Solo/Duo"
+		const rankedSoloDuoTable = $("table").filter((i, table) => {
+			return $(table).find("caption").text().trim() === "Ranked Solo/Duo";
+		});
 
-        if (rankedSoloDuoTable.length) {
-            // Iterate over each row in the tbody of the target table
-            rankedSoloDuoTable.find('tbody tr').each((i, row) => {
-                const season = $(row).find('td:first-child strong').text().trim();
-                const tier = $(row).find('td:nth-child(2) span').first().text().trim();
-                const lpText = $(row).find('td:last-child').text().trim();
-                const lp = lpText ? parseInt(lpText, 10) : null;
+		if (rankedSoloDuoTable.length) {
+			// Iterate over each row in the tbody of the target table
+			rankedSoloDuoTable.find("tbody tr").each((i, row) => {
+				const season = $(row).find("td:first-child strong").text().trim();
+				const tier = $(row).find("td:nth-child(2) span").first().text().trim();
+				const lpText = $(row).find("td:last-child").text().trim();
+				let lp = null;
 
-                if (season && tier) {
-                    rankHistory.push({
-                        season,
-                        tier: tier.charAt(0).toUpperCase() + tier.slice(1),
-                        lp,
-                    });
-                }
-            });
-        } else {
-            console.error("Ranked Solo/Duo table not found.");
-        }
+				if (lpText) {
+					// Clean the LP text by removing any commas and "LP" text before parsing
+					const cleanLpText = lpText.replace(/,/g, "").replace(/\s*LP\s*/i, "");
+					lp = parseInt(cleanLpText, 10);
+				}
 
+				if (season && tier) {
+					rankHistory.push({
+						season,
+						tier: tier.charAt(0).toUpperCase() + tier.slice(1),
+						lp,
+					});
+				}
+			});
+		} else {
+			console.error("Ranked Solo/Duo table not found.");
+		}
 
+		if (rankHistory.length > 0) {
+			// Cache the data
+			CACHE.set(cacheKey, {
+				data: rankHistory,
+				expiresAt: Date.now() + CACHE_TTL,
+			});
 
+			// Set appropriate cache headers
+			return NextResponse.json(rankHistory, {
+				status: 200,
+				headers: {
+					"Cache-Control": "public, max-age=86400",
+					"X-Cache": "MISS",
+					"X-Cache-Expires": new Date(Date.now() + CACHE_TTL).toUTCString(),
+				},
+			});
+		}
 
-        if (rankHistory.length > 0) {
-            // Cache the data
-            CACHE.set(cacheKey, {
-                data: rankHistory,
-                expiresAt: Date.now() + CACHE_TTL
-            });
+		const rankRows = [];
+		$("tbody > tr").each((i, row) => {
+			const seasonElem = $(row).find('strong[class*="text-[11px]"]');
+			const tierElem = $(row).find('span[class*="text-xs"]');
+			const lpElem = $(row).find('td[align="right"]');
 
-            // Set appropriate cache headers
-            return NextResponse.json(rankHistory, {
-                status: 200,
-                headers: {
-                    "Cache-Control": "public, max-age=86400",
-                    "X-Cache": "MISS",
-                    "X-Cache-Expires": new Date(Date.now() + CACHE_TTL).toUTCString()
-                }
-            });
-        }
+			if (seasonElem.length && tierElem.length && lpElem.length) {
+				const season = seasonElem.text().trim();
+				const tier = tierElem.text().trim();
+				const lpText = lpElem.text().trim();
+				let lp = null;
 
-        const rankRows = [];
-        $('tbody > tr').each((i, row) => {
-            const seasonElem = $(row).find('strong[class*="text-[11px]"]');
-            const tierElem = $(row).find('span[class*="text-xs"]');
-            const lpElem = $(row).find('td[align="right"]');
+				if (lpText) {
+					// Clean the LP text by removing any commas and "LP" text before parsing
+					const cleanLpText = lpText.replace(/,/g, "").replace(/\s*LP\s*/i, "");
+					lp = parseInt(cleanLpText, 10);
+				}
 
-            if (seasonElem.length && tierElem.length && lpElem.length) {
-                const season = seasonElem.text().trim();
-                const tier = tierElem.text().trim();
-                const lpText = lpElem.text().trim();
-                let lp = null;
+				if (season && tier) {
+					rankRows.push({
+						season,
+						tier: tier.charAt(0).toUpperCase() + tier.slice(1),
+						lp,
+					});
+				}
+			}
+		});
 
-                if (lpText) {
-                    lp = parseInt(lpText, 10);
-                }
+		if (rankRows.length > 0) {
+			console.log("Used alternative parsing for rank history:", rankRows);
 
-                if (season && tier) {
-                    rankRows.push({
-                        season,
-                        tier: tier.charAt(0).toUpperCase() + tier.slice(1),
-                        lp
-                    });
-                }
-            }
-        });
+			// Cache the data
+			CACHE.set(cacheKey, {
+				data: rankRows,
+				expiresAt: Date.now() + CACHE_TTL,
+			});
 
-        if (rankRows.length > 0) {
-            console.log("Used alternative parsing for rank history:", rankRows);
+			return NextResponse.json(rankRows, {
+				status: 200,
+				headers: {
+					"Cache-Control": "public, max-age=86400",
+					"X-Cache": "MISS",
+					"X-Cache-Expires": new Date(Date.now() + CACHE_TTL).toUTCString(),
+				},
+			});
+		}
 
-            // Cache the data
-            CACHE.set(cacheKey, {
-                data: rankRows,
-                expiresAt: Date.now() + CACHE_TTL
-            });
+		// Try direct approach as a last resort
+		try {
+			const fragment = cheerio.load("<table>" + html + "</table>");
+			const directRows = [];
 
-            return NextResponse.json(rankRows, {
-                status: 200,
-                headers: {
-                    "Cache-Control": "public, max-age=86400",
-                    "X-Cache": "MISS",
-                    "X-Cache-Expires": new Date(Date.now() + CACHE_TTL).toUTCString()
-                }
-            });
-        }
+			fragment("tr").each((i, row) => {
+				const season = fragment(row).find("strong").text().trim();
+				const tier = fragment(row).find("span.text-xs").text().trim();
+				const lpText = fragment(row).find('td[align="right"]').text().trim();
+				let lp = null;
 
-        // Try direct approach as a last resort
-        try {
-            const fragment = cheerio.load('<table>' + html + '</table>');
-            const directRows = [];
+				if (lpText) {
+					// Clean the LP text by removing any commas and "LP" text before parsing
+					const cleanLpText = lpText.replace(/,/g, "").replace(/\s*LP\s*/i, "");
+					lp = parseInt(cleanLpText, 10);
+				}
 
-            fragment('tr').each((i, row) => {
-                const season = fragment(row).find('strong').text().trim();
-                const tier = fragment(row).find('span.text-xs').text().trim();
-                const lpText = fragment(row).find('td[align="right"]').text().trim();
-                let lp = null;
+				if (season && tier) {
+					directRows.push({
+						season,
+						tier: tier.charAt(0).toUpperCase() + tier.slice(1),
+						lp,
+					});
+				}
+			});
 
-                if (lpText) {
-                    lp = parseInt(lpText, 10);
-                }
+			if (directRows.length > 0) {
+				console.log("Used direct HTML fragment parsing:", directRows);
 
-                if (season && tier) {
-                    directRows.push({
-                        season,
-                        tier: tier.charAt(0).toUpperCase() + tier.slice(1),
-                        lp
-                    });
-                }
-            });
+				// Cache the data
+				CACHE.set(cacheKey, {
+					data: directRows,
+					expiresAt: Date.now() + CACHE_TTL,
+				});
 
-            if (directRows.length > 0) {
-                console.log("Used direct HTML fragment parsing:", directRows);
+				return NextResponse.json(directRows, {
+					status: 200,
+					headers: {
+						"Cache-Control": "public, max-age=86400",
+						"X-Cache": "MISS",
+						"X-Cache-Expires": new Date(Date.now() + CACHE_TTL).toUTCString(),
+					},
+				});
+			}
+		} catch (fragmentError) {
+			console.error("Error parsing HTML fragment:", fragmentError);
+		}
 
-                // Cache the data
-                CACHE.set(cacheKey, {
-                    data: directRows,
-                    expiresAt: Date.now() + CACHE_TTL
-                });
+		// If all attempts failed, return an empty array
+		console.log("All parsing attempts failed. No rank history found.");
 
-                return NextResponse.json(directRows, {
-                    status: 200,
-                    headers: {
-                        "Cache-Control": "public, max-age=86400",
-                        "X-Cache": "MISS",
-                        "X-Cache-Expires": new Date(Date.now() + CACHE_TTL).toUTCString()
-                    }
-                });
-            }
-        } catch (fragmentError) {
-            console.error("Error parsing HTML fragment:", fragmentError);
-        }
+		return NextResponse.json([], {
+			status: 200,
+			headers: {
+				"Cache-Control": "public, max-age=21600",
+				"X-Cache": "MISS",
+			},
+		});
+	} catch (error) {
+		console.error("Error scraping rank history:", error.message);
+		if (error.response) {
+			console.error("HTTP Status:", error.response.status);
+			console.error("Response headers:", error.response.headers);
+		}
 
-        // If all attempts failed, return an empty array
-        console.log("All parsing attempts failed. No rank history found.");
-
-        return NextResponse.json([], {
-            status: 200,
-            headers: {
-                "Cache-Control": "public, max-age=21600",
-                "X-Cache": "MISS"
-            }
-        });
-
-    } catch (error) {
-        console.error("Error scraping rank history:", error.message);
-        if (error.response) {
-            console.error("HTTP Status:", error.response.status);
-            console.error("Response headers:", error.response.headers);
-        }
-
-        // Return an empty array with appropriate status code
-        return NextResponse.json([], {
-            status: 200,
-            headers: {
-                "Cache-Control": "no-store",
-                "X-Error": "Failed to fetch rank history"
-            }
-        });
-    }
+		// Return an empty array with appropriate status code
+		return NextResponse.json([], {
+			status: 200,
+			headers: {
+				"Cache-Control": "no-store",
+				"X-Error": "Failed to fetch rank history",
+			},
+		});
+	}
 }


### PR DESCRIPTION
This pull request includes several formatting improvements and minor refactoring to the `GET` function in the `src/app/api/league/rankHistory/route.js` file. The changes primarily focus on consistent use of double quotes and improving readability by cleaning up the LP text parsing.

Formatting improvements:

* Applied prettier formatting

 Bug Fix:

* LP above 1000 now shows correctly due to improvements of cleaning up the LP text parsing

![clutchgg-season-history-bug-fix](https://github.com/user-attachments/assets/de47cfc4-10df-4122-869f-33865a10d602)
