### PR TITLE
refactor(MatchDetails): Remove unused 'isNew' property from tabs

### DIFF
--- a/src/components/league/MatchDetails.js
+++ b/src/components/league/MatchDetails.js
@@ -20,14 +20,12 @@ export default function MatchDetails(props) {
 			id: "analysis",
 			label: "Team Breakdown",
 			icon: <FaChartBar className="mr-2" />,
-			isNew: true,
 			component: <TeamAnalysisTab {...props} />,
 		},
 		{
 			id: "stats",
 			label: "In Depth Stats",
 			icon: <FaListAlt className="mr-2" />,
-			isNew: true,
 			component: <StatsTab {...props} />,
 		},
 	];
@@ -43,10 +41,11 @@ export default function MatchDetails(props) {
 							className={`
                 flex items-center px-4 py-3 font-medium text-sm relative
                 transition-colors duration-200
-                ${activeTab === tab.id
-								? "text-[--primary]"
-								: "text-[--text-secondary] hover:text-[--text-primary]"
-							}
+                ${
+									activeTab === tab.id
+										? "text-[--primary]"
+										: "text-[--text-secondary] hover:text-[--text-primary]"
+								}
               `}
 							onClick={() => setActiveTab(tab.id)}
 						>
@@ -56,8 +55,8 @@ export default function MatchDetails(props) {
 							{/* New badge */}
 							{tab.isNew && (
 								<span className="ml-2 bg-[--primary] text-white text-[10px] px-1.5 py-0.5 rounded-full">
-                  New
-                </span>
+									New
+								</span>
 							)}
 
 							{/* Active indicator */}
@@ -71,7 +70,7 @@ export default function MatchDetails(props) {
 
 			{/* Tab Content */}
 			<div className="pt-2">
-				{tabs.find(tab => tab.id === activeTab)?.component}
+				{tabs.find((tab) => tab.id === activeTab)?.component}
 			</div>
 		</div>
 	);


### PR DESCRIPTION
This pull request includes changes to the `MatchDetails` component in the `src/components/league/MatchDetails.js` file. The main changes involve the removal of the `isNew` property from the tab configuration objects, improvements to the readability of the conditional class assignment, and minor formatting adjustments.

Changes to `MatchDetails` component:

* Removed the `isNew` property from the tab configuration objects for "Team Breakdown" and "In Depth Stats" tabs.
* Improved readability of the conditional class assignment for the active tab by adjusting the indentation.
* Added parentheses around the arrow function parameter in the `find` method for consistency and readability.

![clutchgg-match-details-task-fix](https://github.com/user-attachments/assets/404e5839-edf5-41a2-937c-2a5e20ff0cc6)