### PR TITLE
feat(TFT): add leaderboard and profile API routes with data fetching

### DIFF
--- a/src/app/api/tft/leaderboard/route.js
+++ b/src/app/api/tft/leaderboard/route.js
@@ -1,0 +1,97 @@
+import { NextResponse } from "next/server";
+import { fetchTFTSummonerPUUID } from "@/lib/tft/tftApi";
+import { fetchAccountDataByPUUID } from "@/lib/league/leagueApi";
+
+const TFT_API_KEY = process.env.TFT_API_KEY;
+
+// Simple retry helper (1 extra attempt)
+async function fetchWithRetry(fn, args, retries = 1) {
+	try {
+		return await fn(...args);
+	} catch (error) {
+		if (retries > 0) {
+			return await fetchWithRetry(fn, args, retries - 1);
+		}
+		throw error;
+	}
+}
+
+export async function GET(req) {
+	const { searchParams } = new URL(req.url);
+	const tier = searchParams.get("tier") || "CHALLENGER";
+	const division = searchParams.get("division") || "I";
+	const region = searchParams.get("region") || "euw1";
+	const apiUrl = `https://${region}.api.riotgames.com/tft/league/v1/entries/${tier}/${division}?page=1`;
+
+	try {
+		const response = await fetch(apiUrl, {
+			headers: { "X-Riot-Token": TFT_API_KEY },
+		});
+
+		if (!response.ok) {
+			console.error(
+				`TFT API returned non-OK status: ${response.status} ${response.statusText}`
+			);
+			return NextResponse.json([], { status: 200 });
+		}
+
+		let leaderboardData = [];
+		try {
+			leaderboardData = await response.json();
+		} catch (parseErr) {
+			console.error("Failed to parse TFT API JSON:", parseErr);
+			return NextResponse.json([], { status: 200 });
+		}
+
+		if (!Array.isArray(leaderboardData) || leaderboardData.length === 0) {
+			return NextResponse.json([]);
+		}
+
+		const detailedResults = await Promise.allSettled(
+			leaderboardData.map(async (entry) => {
+				try {
+					const { puuid, profileIconId } = await fetchWithRetry(
+						fetchTFTSummonerPUUID,
+						[entry.summonerId, region],
+						1
+					);
+					// Use the shared account data endpoint since it's game-agnostic
+					const accountData = await fetchWithRetry(
+						fetchAccountDataByPUUID,
+						[puuid],
+						1
+					);
+					return {
+						...entry,
+						profileData: {
+							gameName: accountData.gameName,
+							tagLine: accountData.tagLine,
+							profileIconId,
+						},
+					};
+				} catch (error) {
+					// Suppressing enrichment error messages, returning fallback data instead.
+					return {
+						...entry,
+						profileData: {
+							gameName: "Unknown",
+							tagLine: "Unknown",
+							profileIconId: null,
+						},
+					};
+				}
+			})
+		);
+
+		const detailedData = detailedResults.map((result) =>
+			result.status === "fulfilled" ? result.value : {}
+		);
+
+		return NextResponse.json(detailedData, {
+			headers: { "Cache-Control": "s-maxage=60, stale-while-revalidate" },
+		});
+	} catch (error) {
+		console.error("Error in TFT leaderboard API route:", error);
+		return NextResponse.json([], { status: 200 });
+	}
+}

--- a/src/app/api/tft/profile/route.js
+++ b/src/app/api/tft/profile/route.js
@@ -1,0 +1,196 @@
+import { supabase } from "@/lib/supabase";
+import { fetchAccountData } from "@/lib/riot/riotAccountApi";
+import {
+	fetchTFTSummonerData,
+	fetchTFTRankedData,
+	fetchTFTMatchIds,
+	fetchTFTMatchDetail,
+	upsertTFTMatchDetail,
+} from "@/lib/tft/tftApi";
+
+// TFT uses the same region to platform mapping as League
+const regionToPlatform = {
+	BR1: "americas",
+	EUN1: "europe",
+	EUW1: "europe",
+	JP1: "asia",
+	KR: "asia",
+	LA1: "americas",
+	LA2: "americas",
+	ME1: "europe",
+	NA1: "americas",
+	OC1: "sea",
+	RU: "europe",
+	SG2: "sea",
+	TR1: "europe",
+	TW2: "sea",
+	VN2: "sea",
+};
+
+export async function GET(req) {
+	const { searchParams } = new URL(req.url);
+	const gameName = searchParams.get("gameName");
+	const tagLine = searchParams.get("tagLine");
+	const region = searchParams.get("region");
+	const forceUpdate = searchParams.get("forceUpdate") === "true";
+
+	if (!gameName || !tagLine || !region) {
+		return new Response(
+			JSON.stringify({ error: "Missing required query parameters" }),
+			{ status: 400, headers: { "Content-Type": "application/json" } }
+		);
+	}
+
+	try {
+		// Fetch account data to get the puuid.
+		const platform = regionToPlatform[region];
+		const accountData = await fetchAccountData(gameName, tagLine, platform);
+
+		if (!accountData?.puuid) {
+			return new Response(
+				JSON.stringify({ error: "Invalid Riot account data." }),
+				{ status: 404, headers: { "Content-Type": "application/json" } }
+			);
+		}
+
+		// Check and insert the Riot account as needed.
+		let { data: riotAccount, error: puuidCheckError } = await supabase
+			.from("riot_accounts")
+			.select("*")
+			.eq("puuid", accountData.puuid)
+			.maybeSingle();
+		if (puuidCheckError) throw puuidCheckError;
+
+		if (!riotAccount) {
+			const insertPayload = {
+				gamename: gameName,
+				tagline: tagLine,
+				region,
+				puuid: accountData.puuid,
+			};
+			const { error: insertError } = await supabase
+				.from("riot_accounts")
+				.insert([insertPayload], { returning: "representation" });
+			if (insertError) throw insertError;
+
+			const { data: fetchedAccount, error: fetchError } = await supabase
+				.from("riot_accounts")
+				.select("*")
+				.eq("puuid", accountData.puuid)
+				.maybeSingle();
+			if (fetchError) throw fetchError;
+			riotAccount = fetchedAccount;
+		}
+
+		if (!riotAccount?.puuid) {
+			throw new Error("Riot account record is missing the puuid.");
+		}
+
+		// Return stored TFT data if forceUpdate isn't requested.
+		if (!forceUpdate) {
+			let { data: storedTFTData, error: tftDataError } = await supabase
+				.from("tft_data")
+				.select("*")
+				.eq("riot_account_id", riotAccount.id)
+				.maybeSingle();
+			if (tftDataError) throw tftDataError;
+			if (storedTFTData) {
+				return new Response(JSON.stringify(storedTFTData), {
+					status: 200,
+					headers: { "Content-Type": "application/json" },
+				});
+			}
+		}
+
+		const puuid = riotAccount.puuid;
+
+		// Fetch summoner data once and use it for ranked data.
+		const summonerData = await fetchTFTSummonerData(puuid, region);
+		const [rankedData, matchIds] = await Promise.all([
+			fetchTFTRankedData(summonerData.id, region),
+			fetchTFTMatchIds(puuid, platform),
+		]);
+
+		// Fetch match details concurrently.
+		const matchDetails = await Promise.all(
+			matchIds.map(async (matchId) => {
+				const matchDetail = await fetchTFTMatchDetail(matchId, platform);
+				if (matchDetail)
+					await upsertTFTMatchDetail(matchId, summonerData.puuid, matchDetail);
+				return matchDetail;
+			})
+		);
+
+		const tftDataObj = {
+			profiledata: summonerData,
+			accountdata: {
+				gameName: riotAccount.gamename,
+				tagLine: riotAccount.tagline,
+			},
+			rankeddata: rankedData,
+			matchdata: matchIds,
+			matchdetails: matchDetails,
+			updatedat: new Date(),
+		};
+
+		let { data: tftRecord, error: tftError } = await supabase
+			.from("tft_data")
+			.upsert(
+				{
+					riot_account_id: riotAccount.id,
+					...tftDataObj,
+				},
+				{ onConflict: ["riot_account_id"], returning: "representation" }
+			)
+			.single();
+		if (tftError) throw tftError;
+
+		if (!tftRecord) {
+			const { data: selectedTFTData, error: selectError } = await supabase
+				.from("tft_data")
+				.select("*")
+				.eq("riot_account_id", riotAccount.id)
+				.maybeSingle();
+			if (selectError) throw selectError;
+			tftRecord = selectedTFTData;
+		}
+
+		return new Response(JSON.stringify(tftRecord), {
+			status: 200,
+			headers: { "Content-Type": "application/json" },
+		});
+	} catch (error) {
+		console.error("Error fetching TFT profile data:", error);
+		return new Response(JSON.stringify({ error: error.message }), {
+			status: 500,
+			headers: { "Content-Type": "application/json" },
+		});
+	}
+}
+
+export async function POST(req) {
+	try {
+		const { gameName, tagLine, region } = await req.json();
+		if (!gameName || !tagLine || !region) {
+			return new Response(
+				JSON.stringify({ error: "Missing required parameters" }),
+				{ status: 400, headers: { "Content-Type": "application/json" } }
+			);
+		}
+		const url = new URL(req.url);
+		url.searchParams.set("gameName", gameName);
+		url.searchParams.set("tagLine", tagLine);
+		url.searchParams.set("region", region);
+		url.searchParams.set("forceUpdate", "true");
+
+		return await GET(
+			new Request(url.toString(), { method: "GET", headers: req.headers })
+		);
+	} catch (error) {
+		console.error("Error updating TFT profile:", error);
+		return new Response(JSON.stringify({ error: error.message }), {
+			status: 500,
+			headers: { "Content-Type": "application/json" },
+		});
+	}
+}


### PR DESCRIPTION
This pull request introduces new API routes for fetching and updating Teamfight Tactics (TFT) leaderboard and profile data. The changes include adding new helper functions, integrating with external APIs, and handling errors gracefully.

New API routes:

* [`src/app/api/tft/leaderboard/route.js`](diffhunk://#diff-9790d991f20a5a1b5f2bdfb278ec2bf3edbeeb4d8fbd29f24f9456dd54d8ef62R1-R97): Added a new GET route to fetch TFT leaderboard data, including retry logic for external API calls and detailed profile enrichment.
* [`src/app/api/tft/profile/route.js`](diffhunk://#diff-2155b42b8856fa4460759ba83b2b48fd366cbf8b37fbc3983da464bb7c94fabaR1-R196): Added new GET and POST routes to fetch and update TFT profile data, including integration with Supabase for data storage and handling force updates.