### PR TITLE
feat(TFT): implement hooks and API functions for fetching profile data

### DIFF
--- a/src/app/hooks/tft/useProfileData.js
+++ b/src/app/hooks/tft/useProfileData.js
@@ -1,0 +1,43 @@
+import { useState, useEffect } from "react";
+
+export default function useTFTProfileData(profileData) {
+	const [summonerData, setSummonerData] = useState(null);
+	const [rankedData, setRankedData] = useState([]);
+	const [matchData, setMatchData] = useState([]);
+	const [matchDetails, setMatchDetails] = useState([]);
+	const [isLoading, setIsLoading] = useState(true);
+
+	useEffect(() => {
+		if (profileData) {
+			setSummonerData({
+				name: profileData.accountdata?.gameName || "Unknown",
+				tagLine: profileData.accountdata?.tagLine || "Unknown",
+				profileIconId: profileData.profiledata?.profileIconId || 1,
+				summonerLevel: profileData.profiledata?.summonerLevel || 0,
+				puuid: profileData.profiledata?.puuid || "",
+			});
+
+			setRankedData(profileData.rankeddata || []);
+			setMatchData(profileData.matchdata || []);
+			setMatchDetails(
+				profileData.matchdetails?.filter(Boolean).map((match) => {
+					return {
+						...match,
+						metadata: match.metadata || {},
+						info: match.info || {},
+					};
+				}) || []
+			);
+
+			setIsLoading(false);
+		}
+	}, [profileData]);
+
+	return {
+		summonerData,
+		rankedData,
+		matchData,
+		matchDetails,
+		isLoading,
+	};
+}

--- a/src/lib/tft/tftApi.js
+++ b/src/lib/tft/tftApi.js
@@ -1,0 +1,152 @@
+import { supabase } from "@/lib/supabase";
+
+const TFT_API_KEY = process.env.TFT_API_KEY;
+
+/**
+ * Fetch TFT summoner data using an encrypted PUUID.
+ */
+export const fetchTFTSummonerData = async (encryptedPUUID, region) => {
+	const summonerResponse = await fetch(
+		`https://${region}.api.riotgames.com/tft/summoner/v1/summoners/by-puuid/${encryptedPUUID}`,
+		{ headers: { "X-Riot-Token": TFT_API_KEY } }
+	);
+	if (!summonerResponse.ok) {
+		throw new Error("Failed to fetch TFT summoner data");
+	}
+	return summonerResponse.json();
+};
+
+/**
+ * Fetch TFT ranked data.
+ */
+export const fetchTFTRankedData = async (summonerId, region) => {
+	const rankedResponse = await fetch(
+		`https://${region}.api.riotgames.com/tft/league/v1/entries/by-summoner/${summonerId}`,
+		{ headers: { "X-Riot-Token": TFT_API_KEY } }
+	);
+	if (!rankedResponse.ok) {
+		throw new Error("Failed to fetch TFT ranked data");
+	}
+	return rankedResponse.json();
+};
+
+/**
+ * Fetch TFT match IDs.
+ */
+export const fetchTFTMatchIds = async (encryptedPUUID, platform) => {
+	const matchResponse = await fetch(
+		`https://${platform}.api.riotgames.com/tft/match/v1/matches/by-puuid/${encryptedPUUID}/ids?count=20`,
+		{ headers: { "X-Riot-Token": TFT_API_KEY } }
+	);
+	if (!matchResponse.ok) {
+		throw new Error("Failed to fetch TFT match data");
+	}
+	return matchResponse.json();
+};
+
+/**
+ * Fetch detailed TFT match data.
+ */
+export const fetchTFTMatchDetail = async (matchId, platform) => {
+	const matchDetailResponse = await fetch(
+		`https://${platform}.api.riotgames.com/tft/match/v1/matches/${matchId}`,
+		{ headers: { "X-Riot-Token": TFT_API_KEY } }
+	);
+	if (!matchDetailResponse.ok) {
+		return null;
+	}
+	return matchDetailResponse.json();
+};
+
+/**
+ * Upsert TFT match detail into the matches table.
+ * Only stores the matchid and playerid as reference for cached matches.
+ */
+export const upsertTFTMatchDetail = async (matchId, puuid, matchDetail) => {
+	const { error: insertMatchError } = await supabase.from("tft_matches").upsert(
+		{
+			matchid: matchId,
+			playerid: puuid,
+			// removed match_data as the column doesn't exist in the table
+		},
+		{ onConflict: ["matchid"] }
+	);
+	if (insertMatchError) {
+		console.error("Error inserting TFT match:", insertMatchError);
+	}
+};
+
+/**
+ * Fetch additional data for TFT player enrichment.
+ */
+export const fetchTFTAdditionalData = async (summonerId, puuid, region) => {
+	try {
+		const [rankedResponse, accountResponse, summonerResponse] =
+			await Promise.all([
+				fetch(
+					`https://${region}.api.riotgames.com/tft/league/v1/entries/by-summoner/${summonerId}`,
+					{ headers: { "X-Riot-Token": TFT_API_KEY } }
+				),
+				fetch(
+					`https://europe.api.riotgames.com/riot/account/v1/accounts/by-puuid/${puuid}`,
+					{ headers: { "X-Riot-Token": TFT_API_KEY } }
+				),
+				fetch(
+					`https://${region}.api.riotgames.com/tft/summoner/v1/summoners/by-puuid/${puuid}`,
+					{ headers: { "X-Riot-Token": TFT_API_KEY } }
+				),
+			]);
+
+		if (!rankedResponse.ok || !accountResponse.ok || !summonerResponse.ok) {
+			throw new Error("Failed to fetch additional TFT data");
+		}
+
+		const [rankedData, accountData, summonerData] = await Promise.all([
+			rankedResponse.json(),
+			accountResponse.json(),
+			summonerResponse.json(),
+		]);
+
+		// TFT ranked data structure is different from League
+		const rankedTftData = rankedData.find(
+			(queue) => queue.queueType === "RANKED_TFT"
+		);
+
+		return {
+			rank: rankedTftData
+				? `${rankedTftData.tier} ${rankedTftData.rank}`
+				: "Unranked",
+			lp: rankedTftData ? rankedTftData.leaguePoints : 0,
+			wins: rankedTftData ? rankedTftData.wins : 0,
+			losses: rankedTftData ? rankedTftData.losses : 0,
+			gameName: accountData.gameName,
+			tagLine: accountData.tagLine,
+			summonerLevel: summonerData.summonerLevel,
+		};
+	} catch (error) {
+		return {
+			rank: "Unranked",
+			lp: 0,
+			wins: 0,
+			losses: 0,
+			gameName: "",
+			tagLine: "",
+			summonerLevel: 0,
+		};
+	}
+};
+
+/**
+ * Fetch TFT summoner details to get the PUUID and profile icon.
+ */
+export const fetchTFTSummonerPUUID = async (summonerId, region) => {
+	const response = await fetch(
+		`https://${region}.api.riotgames.com/tft/summoner/v1/summoners/${summonerId}`,
+		{ headers: { "X-Riot-Token": TFT_API_KEY } }
+	);
+	if (!response.ok) {
+		throw new Error(`Failed to fetch PUUID for TFT summonerId: ${summonerId}`);
+	}
+	const data = await response.json();
+	return { puuid: data.puuid, profileIconId: data.profileIconId };
+};


### PR DESCRIPTION
This pull request introduces a new hook for fetching and managing TFT (Teamfight Tactics) profile data and adds several API functions to handle various aspects of the TFT data retrieval process.

### New Hook for TFT Profile Data:
* [`src/app/hooks/tft/useProfileData.js`](diffhunk://#diff-ac6be687f79ac6ed97df9886c95bf8deb5bfe2c59a1fc6e7b60526414dcb1faeR1-R43): Created a new hook `useTFTProfileData` to manage TFT profile data, including summoner data, ranked data, match data, and match details. The hook uses state variables and the `useEffect` hook to update the state based on the provided `profileData`.

### API Functions for TFT Data Retrieval:
* [`src/lib/tft/tftApi.js`](diffhunk://#diff-ddf6efaca7bc08ed3bac80bf3cd34ce77b4a5fbbabe3e5fddce7f2afe372f62fR1-R152): Added multiple functions to fetch TFT data from the Riot Games API, including summoner data, ranked data, match IDs, match details, and additional player enrichment data. These functions use the `fetch` API with the appropriate endpoints and handle errors gracefully.

Key changes include:
* `fetchTFTSummonerData`: Fetches summoner data using an encrypted PUUID and region.
* `fetchTFTRankedData`: Fetches ranked data for a summoner.
* `fetchTFTMatchIds`: Fetches match IDs for a summoner.
* `fetchTFTMatchDetail`: Fetches detailed match data for a given match ID.
* `upsertTFTMatchDetail`: Inserts or updates match details in the database.
* `fetchTFTAdditionalData`: Fetches additional data for player enrichment.
* `fetchTFTSummonerPUUID`: Fetches summoner details to get the PUUID and profile icon.