### PR TITLE
feat(TFT): add leaderboard and profile pages with data fetching

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -3,257 +3,270 @@
 @tailwind utilities;
 
 :root {
-    --primary: #3a86ff;
-    --primary-dark: #2667cc;
-    --secondary: #8338ec;
-    --accent: #ff006e;
-    --background: #0e1015;
-    --card-bg: #1a1d26;
-    --card-bg-secondary: #232337;
-    --card-border: #2f2f46;
-    --text-primary: #ffffff;
-    --text-secondary: #94a3b8;
-    --success: #10b981;
-    --error: #ef4444;
-    --warning: #f59e0b;
-    --iron: #6e6e6e;
-    --bronze: #a26220;
-    --silver: #95a5a6;
-    --gold: #f0b267;
-    --platinum: #35c2c2;
-    --emerald: #04a86c;
-    --diamond: #738ff5;
-    --master: #9d4dc5;
-    --grandmaster: #d73636;
-    --challenger: #e8be56;
+	--primary: #3a86ff;
+	--primary-dark: #2667cc;
+	--secondary: #8338ec;
+	--accent: #ff006e;
+	--background: #0e1015;
+	--card-bg: #1a1d26;
+	--card-bg-secondary: #232337;
+	--card-border: #2f2f46;
+	--text-primary: #ffffff;
+	--text-secondary: #94a3b8;
+	--success: #10b981;
+	--error: #ef4444;
+	--warning: #f59e0b;
+	--iron: #6e6e6e;
+	--bronze: #a26220;
+	--silver: #95a5a6;
+	--gold: #f0b267;
+	--platinum: #35c2c2;
+	--emerald: #04a86c;
+	--diamond: #738ff5;
+	--master: #9d4dc5;
+	--grandmaster: #d73636;
+	--challenger: #e8be56;
 }
 
 @layer base {
-    body {
-        @apply bg-[--background] text-[--text-primary] font-sans;
-    }
+	body {
+		@apply bg-[--background] text-[--text-primary] font-sans;
+	}
 
-    h1, h2, h3, h4, h5, h6 {
-        @apply font-bold;
-    }
+	h1,
+	h2,
+	h3,
+	h4,
+	h5,
+	h6 {
+		@apply font-bold;
+	}
 }
 
 @layer components {
-    .card {
-        @apply bg-[--card-bg] border border-[--card-border] rounded-xl p-4 shadow-lg transition-all duration-200;
-    }
+	.card {
+		@apply bg-[--card-bg] border border-[--card-border] rounded-xl p-4 shadow-lg transition-all duration-200;
+	}
 
-    .card-highlight {
-        @apply bg-gradient-to-br from-[--card-bg-secondary] to-[--card-bg] border border-[--card-border] rounded-xl p-4 shadow-lg;
-    }
+	.card-highlight {
+		@apply bg-gradient-to-br from-[--card-bg-secondary] to-[--card-bg] border border-[--card-border] rounded-xl p-4 shadow-lg;
+	}
 
-    .btn-primary {
-        @apply bg-[--primary] hover:bg-[--primary-dark] text-white px-4 py-2 rounded-lg font-medium transition-colors duration-200;
-    }
+	.btn-primary {
+		@apply bg-[--primary] hover:bg-[--primary-dark] text-white px-4 py-2 rounded-lg font-medium transition-colors duration-200;
+	}
 
-    .btn-secondary {
-        @apply bg-[--secondary] hover:opacity-90 text-white px-4 py-2 rounded-lg font-medium transition-colors duration-200;
-    }
+	.btn-secondary {
+		@apply bg-[--secondary] hover:opacity-90 text-white px-4 py-2 rounded-lg font-medium transition-colors duration-200;
+	}
 
-    .btn-outline {
-        @apply border border-[--primary] text-[--primary] hover:bg-[--primary] hover:text-white px-4 py-2 rounded-lg font-medium transition-colors duration-200;
-    }
+	.btn-outline {
+		@apply border border-[--primary] text-[--primary] hover:bg-[--primary] hover:text-white px-4 py-2 rounded-lg font-medium transition-colors duration-200;
+	}
 
-    .btn-success {
-        @apply bg-[--success] hover:opacity-90 text-white px-4 py-2 rounded-lg font-medium transition-colors duration-200;
-    }
+	.btn-success {
+		@apply bg-[--success] hover:opacity-90 text-white px-4 py-2 rounded-lg font-medium transition-colors duration-200;
+	}
 
-    .btn-error {
-        @apply bg-[--error] hover:opacity-90 text-white px-4 py-2 rounded-lg font-medium transition-colors duration-200;
-    }
+	.btn-error {
+		@apply bg-[--error] hover:opacity-90 text-white px-4 py-2 rounded-lg font-medium transition-colors duration-200;
+	}
 
-    .nav-link {
-        @apply text-[--text-secondary] hover:text-[--text-primary] transition-colors duration-200;
-    }
+	.nav-link {
+		@apply text-[--text-secondary] hover:text-[--text-primary] transition-colors duration-200;
+	}
 
-    .stat-block {
-        @apply flex flex-col items-center bg-[--card-bg] rounded-lg p-3 text-center;
-    }
+	.stat-block {
+		@apply flex flex-col items-center bg-[--card-bg] rounded-lg p-3 text-center;
+	}
 
-    .match-win {
-        @apply bg-gradient-to-r from-[#172e40] via-[#1a4a6b] to-[#172e40] border-l-4 border-[--success];
-    }
+	.match-win {
+		@apply bg-gradient-to-r from-[#172e40] via-[#1a4a6b] to-[#172e40] border-l-4 border-[--success];
+	}
 
-    .match-loss {
-        @apply bg-gradient-to-r from-[#3a1d1d] via-[#4a2222] to-[#3a1d1d] border-l-4 border-[--error];
-    }
+	.match-loss {
+		@apply bg-gradient-to-r from-[#3a1d1d] via-[#4a2222] to-[#3a1d1d] border-l-4 border-[--error];
+	}
 
-    .match-remake {
-        @apply bg-gradient-to-r from-[#2d2a16] via-[#3d3a1c] to-[#2d2a16] border-l-4 border-[--warning];
-    }
+	.match-remake {
+		@apply bg-gradient-to-r from-[#2d2a16] via-[#3d3a1c] to-[#2d2a16] border-l-4 border-[--warning];
+	}
 
-    .animate-pulse-custom {
-        animation: pulse 2s cubic-bezier(0.4, 0, 0.6, 1) infinite;
-    }
+	.animate-pulse-custom {
+		animation: pulse 2s cubic-bezier(0.4, 0, 0.6, 1) infinite;
+	}
 
-    .rank-icon {
-        @apply relative flex items-center justify-center;
-    }
+	.rank-icon {
+		@apply relative flex items-center justify-center;
+	}
 
-    .rank-icon::after {
-        @apply content-[''] absolute inset-0 rounded-full bg-gradient-to-b opacity-60 -z-10;
-    }
+	.rank-icon::after {
+		@apply content-[''] absolute inset-0 rounded-full bg-gradient-to-b opacity-60 -z-10;
+	}
 
-    .rank-iron::after {
-        @apply from-[--iron] to-transparent;
-    }
+	.rank-iron::after {
+		@apply from-[--iron] to-transparent;
+	}
 
-    .rank-bronze::after {
-        @apply from-[--bronze] to-transparent;
-    }
+	.rank-bronze::after {
+		@apply from-[--bronze] to-transparent;
+	}
 
-    .rank-silver::after {
-        @apply from-[--silver] to-transparent;
-    }
+	.rank-silver::after {
+		@apply from-[--silver] to-transparent;
+	}
 
-    .rank-gold::after {
-        @apply from-[--gold] to-transparent;
-    }
+	.rank-gold::after {
+		@apply from-[--gold] to-transparent;
+	}
 
-    .rank-platinum::after {
-        @apply from-[--platinum] to-transparent;
-    }
+	.rank-platinum::after {
+		@apply from-[--platinum] to-transparent;
+	}
 
-    .rank-emerald::after {
-        @apply from-[--emerald] to-transparent;
-    }
+	.rank-emerald::after {
+		@apply from-[--emerald] to-transparent;
+	}
 
-    .rank-diamond::after {
-        @apply from-[--diamond] to-transparent;
-    }
+	.rank-diamond::after {
+		@apply from-[--diamond] to-transparent;
+	}
 
-    .rank-master::after {
-        @apply from-[--master] to-transparent;
-    }
+	.rank-master::after {
+		@apply from-[--master] to-transparent;
+	}
 
-    .rank-grandmaster::after {
-        @apply from-[--grandmaster] to-transparent;
-    }
+	.rank-grandmaster::after {
+		@apply from-[--grandmaster] to-transparent;
+	}
 
-    .rank-challenger::after {
-        @apply from-[--challenger] to-transparent;
-    }
+	.rank-challenger::after {
+		@apply from-[--challenger] to-transparent;
+	}
 
-    /* Stat Card Animation */
-    .stat-card {
-        @apply relative overflow-hidden;
-    }
+	/* Stat Card Animation */
+	.stat-card {
+		@apply relative overflow-hidden;
+	}
 
-    .stat-card::before {
-        @apply content-[''] absolute -inset-1 z-0 bg-gradient-to-r from-transparent via-[--primary] to-transparent opacity-0 transition-opacity duration-1000;
-        transform: rotate(45deg);
-    }
+	.stat-card::before {
+		@apply content-[''] absolute -inset-1 z-0 bg-gradient-to-r from-transparent via-[--primary] to-transparent opacity-0 transition-opacity duration-1000;
+		transform: rotate(45deg);
+	}
 
-    .stat-card:hover::before {
-        @apply opacity-20;
-        animation: shine 2s ease-in-out;
-    }
+	.stat-card:hover::before {
+		@apply opacity-20;
+		animation: shine 2s ease-in-out;
+	}
 
-    /* Glass effect */
-    .glass {
-        @apply bg-white/10 backdrop-blur-lg border border-white/20 shadow-lg;
-    }
+	/* Glass effect */
+	.glass {
+		@apply bg-white/10 backdrop-blur-lg border border-white/20 shadow-lg;
+	}
 
-    /* Scrollbar */
-    .custom-scrollbar::-webkit-scrollbar {
-        @apply w-2;
-    }
+	/* Scrollbar */
+	.custom-scrollbar::-webkit-scrollbar {
+		@apply w-2;
+	}
 
-    .custom-scrollbar::-webkit-scrollbar-track {
-        @apply bg-transparent;
-    }
+	.custom-scrollbar::-webkit-scrollbar-track {
+		@apply bg-transparent;
+	}
 
-    .custom-scrollbar::-webkit-scrollbar-thumb {
-        @apply bg-[--card-border] rounded-full;
-    }
+	.custom-scrollbar::-webkit-scrollbar-thumb {
+		@apply bg-[--card-border] rounded-full;
+	}
 
-    .custom-scrollbar::-webkit-scrollbar-thumb:hover {
-        @apply bg-[--primary];
-    }
+	.custom-scrollbar::-webkit-scrollbar-thumb:hover {
+		@apply bg-[--primary];
+	}
 }
 
 @keyframes pulse {
-    0%, 100% {
-        opacity: 1;
-    }
-    50% {
-        opacity: 0.5;
-    }
+	0%,
+	100% {
+		opacity: 1;
+	}
+	50% {
+		opacity: 0.5;
+	}
 }
 
 @keyframes shine {
-    0% {
-        left: -100%;
-        opacity: 0;
-    }
-    50% {
-        opacity: 0.3;
-    }
-    100% {
-        left: 100%;
-        opacity: 0;
-    }
+	0% {
+		left: -100%;
+		opacity: 0;
+	}
+	50% {
+		opacity: 0.3;
+	}
+	100% {
+		left: 100%;
+		opacity: 0;
+	}
 }
 
 /* Profile header background animation */
 .profile-header-bg {
-    background: linear-gradient(45deg, #0e1015, #1a1d26, #232337, #1a1d26, #0e1015);
-    background-size: 400% 400%;
-    animation: gradient 15s ease infinite;
+	background: linear-gradient(
+		45deg,
+		#0e1015,
+		#1a1d26,
+		#232337,
+		#1a1d26,
+		#0e1015
+	);
+	background-size: 400% 400%;
+	animation: gradient 15s ease infinite;
 }
 
 @keyframes gradient {
-    0% {
-        background-position: 0% 50%;
-    }
-    50% {
-        background-position: 100% 50%;
-    }
-    100% {
-        background-position: 0% 50%;
-    }
+	0% {
+		background-position: 0% 50%;
+	}
+	50% {
+		background-position: 100% 50%;
+	}
+	100% {
+		background-position: 0% 50%;
+	}
 }
 
 /* Loading animation */
 .loading-spinner {
-    @apply relative w-16 h-16;
+	@apply relative w-16 h-16;
 }
 
 .loading-spinner::before,
 .loading-spinner::after {
-    @apply content-[''] absolute w-16 h-16 rounded-full border-4 border-transparent;
+	@apply content-[''] absolute w-16 h-16 rounded-full border-4 border-transparent;
 }
 
 .loading-spinner::before {
-    @apply border-t-[--primary] border-r-[--primary] animate-spin;
-    animation-duration: 1s;
+	@apply border-t-[--primary] border-r-[--primary] animate-spin;
+	animation-duration: 1s;
 }
 
 .loading-spinner::after {
-    @apply border-b-[--secondary] border-l-[--secondary] animate-spin;
-    animation-duration: 1.5s;
+	@apply border-b-[--secondary] border-l-[--secondary] animate-spin;
+	animation-duration: 1.5s;
 }
 
 /* Responsive typography */
 @media (max-width: 640px) {
-    html {
-        font-size: 14px;
-    }
+	html {
+		font-size: 14px;
+	}
 }
 
 @media (min-width: 641px) and (max-width: 1024px) {
-    html {
-        font-size: 15px;
-    }
+	html {
+		font-size: 15px;
+	}
 }
 
 @media (min-width: 1025px) {
-    html {
-        font-size: 16px;
-    }
+	html {
+		font-size: 16px;
+	}
 }

--- a/src/app/tft/leaderboard/page.js
+++ b/src/app/tft/leaderboard/page.js
@@ -1,0 +1,138 @@
+"use client";
+
+import { useState, useEffect } from "react";
+import { useSearchParams } from "next/navigation";
+import TFTLeaderboardTable from "@/components/tft/LeaderboardTable";
+import Loading from "@/components/Loading";
+import { Dropdown } from "@/components/tft/Dropdowns";
+
+export default function TFTLeaderboardPage() {
+	const searchParams = useSearchParams();
+	const initialRegion = searchParams.get("region") || "euw1";
+	const initialTier = searchParams.get("tier") || "CHALLENGER";
+	const initialDivision = searchParams.get("division") || "I";
+
+	const [region, setRegion] = useState(initialRegion);
+	const [tier, setTier] = useState(initialTier);
+	const [division, setDivision] = useState(initialDivision);
+	const [leaderboardData, setLeaderboardData] = useState([]);
+	const [isLoading, setIsLoading] = useState(true);
+	const [error, setError] = useState(null);
+
+	const regions = [
+		{ value: "br1", label: "Brazil" },
+		{ value: "eun1", label: "Europe Nordic & East" },
+		{ value: "euw1", label: "Europe West" },
+		{ value: "jp1", label: "Japan" },
+		{ value: "kr", label: "Korea" },
+		{ value: "la1", label: "Latin America North" },
+		{ value: "la2", label: "Latin America South" },
+		{ value: "na1", label: "North America" },
+		{ value: "oc1", label: "Oceania" },
+		{ value: "ru", label: "Russia" },
+		{ value: "tr1", label: "Turkey" },
+	];
+
+	const tiers = [
+		{ value: "IRON", label: "Iron" },
+		{ value: "BRONZE", label: "Bronze" },
+		{ value: "SILVER", label: "Silver" },
+		{ value: "GOLD", label: "Gold" },
+		{ value: "PLATINUM", label: "Platinum" },
+		{ value: "EMERALD", label: "Emerald" },
+		{ value: "DIAMOND", label: "Diamond" },
+		{ value: "MASTER", label: "Master" },
+		{ value: "GRANDMASTER", label: "Grandmaster" },
+		{ value: "CHALLENGER", label: "Challenger" },
+	];
+
+	const divisions = [
+		{ value: "I", label: "I" },
+		{ value: "II", label: "II" },
+		{ value: "III", label: "III" },
+		{ value: "IV", label: "IV" },
+	];
+
+	// Filter out divisions for Master+ tiers
+	const shouldShowDivisions = !["MASTER", "GRANDMASTER", "CHALLENGER"].includes(
+		tier
+	);
+
+	useEffect(() => {
+		async function fetchLeaderboard() {
+			setIsLoading(true);
+			setError(null);
+
+			try {
+				const divisionParam = shouldShowDivisions
+					? `&division=${division}`
+					: "";
+				const response = await fetch(
+					`/api/tft/leaderboard?region=${region}&tier=${tier}${divisionParam}`
+				);
+
+				if (!response.ok) {
+					throw new Error(`Failed to fetch leaderboard: ${response.status}`);
+				}
+
+				const data = await response.json();
+				setLeaderboardData(data);
+			} catch (err) {
+				console.error("Error fetching leaderboard:", err);
+				setError(err.message);
+			} finally {
+				setIsLoading(false);
+			}
+		}
+
+		fetchLeaderboard();
+	}, [region, tier, division, shouldShowDivisions]);
+
+	return (
+		<main className="min-h-screen py-24 bg-gray-900 text-white">
+			<div className="container mx-auto px-4">
+				<h1 className="text-3xl font-bold mb-8 text-center">TFT Leaderboard</h1>
+
+				<div className="flex flex-col md:flex-row gap-4 mb-8 justify-center">
+					<Dropdown
+						label="Region"
+						options={regions}
+						value={region}
+						onChange={(value) => setRegion(value)}
+					/>
+					<Dropdown
+						label="Tier"
+						options={tiers}
+						value={tier}
+						onChange={(value) => {
+							setTier(value);
+							if (!shouldShowDivisions) {
+								setDivision("I");
+							}
+						}}
+					/>
+					{shouldShowDivisions && (
+						<Dropdown
+							label="Division"
+							options={divisions}
+							value={division}
+							onChange={(value) => setDivision(value)}
+						/>
+					)}
+				</div>
+
+				{isLoading ? (
+					<Loading />
+				) : error ? (
+					<div className="text-red-500 text-center">{error}</div>
+				) : leaderboardData.length === 0 ? (
+					<div className="text-center">
+						No data available for the selected criteria.
+					</div>
+				) : (
+					<TFTLeaderboardTable data={leaderboardData} region={region} />
+				)}
+			</div>
+		</main>
+	);
+}

--- a/src/app/tft/profile/page.js
+++ b/src/app/tft/profile/page.js
@@ -1,0 +1,72 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import { useSearchParams } from "next/navigation";
+import Profile from "@/components/tft/Profile";
+import ErrorPage from "@/components/ErrorPage";
+import Loading from "@/components/Loading";
+
+export default function TFTProfilePage() {
+	const searchParams = useSearchParams();
+	const gameName = searchParams.get("gameName");
+	const tagLine = searchParams.get("tagLine");
+	const region = searchParams.get("region");
+	const [profileData, setProfileData] = useState(null);
+	const [isLoading, setIsLoading] = useState(true);
+	const [error, setError] = useState(null);
+
+	useEffect(() => {
+		async function fetchProfileData() {
+			if (!gameName || !tagLine || !region) {
+				setIsLoading(false);
+				return;
+			}
+
+			setIsLoading(true);
+			setError(null);
+
+			try {
+				const response = await fetch(
+					`/api/tft/profile?gameName=${encodeURIComponent(
+						gameName
+					)}&tagLine=${encodeURIComponent(tagLine)}&region=${encodeURIComponent(
+						region
+					)}`
+				);
+
+				if (!response.ok) {
+					throw new Error(
+						`Failed to fetch profile data: ${response.status} ${response.statusText}`
+					);
+				}
+
+				const data = await response.json();
+				setProfileData(data);
+			} catch (err) {
+				console.error("Error fetching profile data:", err);
+				setError(err.message);
+			} finally {
+				setIsLoading(false);
+			}
+		}
+
+		fetchProfileData();
+	}, [gameName, tagLine, region]);
+
+	if (isLoading) {
+		return <Loading />;
+	}
+
+	if (error || !gameName || !tagLine || !region) {
+		return (
+			<ErrorPage
+				message={
+					error ||
+					"Please provide a valid Riot ID (gameName#tagLine) and region."
+				}
+			/>
+		);
+	}
+
+	return <Profile profileData={profileData} />;
+}


### PR DESCRIPTION
This pull request includes several significant updates to the `src/app` directory, primarily focusing on the addition of new pages for the TFT leaderboard and profile, as well as some formatting changes in the global CSS file.

### New Pages:
* [`src/app/tft/leaderboard/page.js`](diffhunk://#diff-a857c1780a307d4c2b5f50d1297a329c8c415868e1597570387d5c1ef3e705d6R1-R138): Added a new client-side page for the TFT leaderboard, including state management, data fetching, and rendering logic for regions, tiers, and divisions.
* [`src/app/tft/profile/page.js`](diffhunk://#diff-cd2b99c6e977adc8dba70b2bfc22c12da47713070b5bb1d89625e12232b5eacfR1-R72): Added a new client-side page for TFT player profiles, including state management, data fetching, and error handling.

### CSS Formatting:
* [`src/app/globals.css`](diffhunk://#diff-4f206759c961f544a48464ad2ee231adc87e72593d03a0004b68c17771f7a412L36-R41): Reformatted CSS rules for headers, keyframes, and profile header background to improve readability. [[1]](diffhunk://#diff-4f206759c961f544a48464ad2ee231adc87e72593d03a0004b68c17771f7a412L36-R41) [[2]](diffhunk://#diff-4f206759c961f544a48464ad2ee231adc87e72593d03a0004b68c17771f7a412L181-R187) [[3]](diffhunk://#diff-4f206759c961f544a48464ad2ee231adc87e72593d03a0004b68c17771f7a412L205-R218)