### PR TITLE
feat: add TFTMatchDetails component

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -180,6 +180,10 @@
 	.custom-scrollbar::-webkit-scrollbar-thumb:hover {
 		@apply bg-[--primary];
 	}
+
+	.animate-fadeIn {
+		animation: fadeIn 0.3s ease-in-out;
+	}
 }
 
 @keyframes pulse {
@@ -203,6 +207,17 @@
 	100% {
 		left: 100%;
 		opacity: 0;
+	}
+}
+
+@keyframes fadeIn {
+	0% {
+		opacity: 0;
+		transform: translateY(-10px);
+	}
+	100% {
+		opacity: 1;
+		transform: translateY(0);
 	}
 }
 

--- a/src/components/tft/MatchDetails.js
+++ b/src/components/tft/MatchDetails.js
@@ -1,0 +1,628 @@
+import React, { useState, useEffect } from "react";
+import Image from "next/image";
+import Link from "next/link";
+import {
+	// FaUsers, // No longer needed for tabs
+	// FaChartBar, // No longer needed for tabs
+	FaStar,
+	FaCoins,
+	FaBolt,
+	FaCrown,
+	// FaTrophy, // Not explicitly used in final design
+	FaSkull, // For eliminations stat
+	FaQuestionCircle, // Placeholder for Augment icons
+} from "react-icons/fa";
+
+// --- Helper Functions ---
+
+// Map Community Dragon paths (Your Original Logic)
+function mapCDragonAssetPath(jsonPath) {
+	if (!jsonPath) return null;
+	// Ensure path starts correctly, remove potential double slashes
+	const cleanPath = jsonPath.replace(/^\/+/, "");
+	const lower = cleanPath.toLowerCase().replace("lol-game-data/assets", ""); // Handle potential leading slash
+	return `https://raw.communitydragon.org/latest/plugins/rcp-be-lol-game-data/global/default/${
+		lower.startsWith("/") ? lower.substring(1) : lower
+	}`;
+}
+
+// Get Champion Image URL (Your Original Logic - RESTORED)
+function getTFTChampionImageUrl(characterId, championName) {
+	if (!characterId) return null;
+	let setNumber = null;
+	const match = characterId.match(/TFT(\d+)/i);
+	if (match && match[1]) {
+		setNumber = parseInt(match[1]);
+	}
+	let championBaseName = characterId.split("_")[1];
+	if (!championBaseName) return null;
+	championBaseName = championBaseName.toLowerCase();
+	// NOTE: The original logic determined the extension based on set number AFTER constructing the base URL.
+	const baseUrl = `https://raw.communitydragon.org/latest/plugins/rcp-be-lol-game-data/global/default/assets/characters/tft${setNumber}_${championBaseName}/hud/tft${setNumber}_${championBaseName}_square.tft_set${setNumber}`;
+	if (setNumber === 14) return `${baseUrl}.jpg`; // Your original logic for Set 14
+	if (setNumber === 13) return `${baseUrl}.png`; // Your original logic for Set 13
+	// Add specific logic for other sets IF your original function had it.
+	// Fallback to png as per your original code.
+	return `${baseUrl}.png`;
+}
+
+// Get Border Color by Cost (UI Styling)
+function getBorderColorForCost(cost) {
+	switch (cost) {
+		case 1:
+			return "border-gray-500";
+		case 2:
+			return "border-green-500";
+		case 3:
+			return "border-blue-500";
+		case 4:
+			return "border-purple-500";
+		case 5:
+			return "border-yellow-500";
+		default:
+			return "border-gray-700";
+	}
+}
+
+// Get Star Color (UI Styling - Matched to Image)
+function getStarColorForCost(cost) {
+	return "text-yellow-400"; // Always gold stars like image
+}
+
+// Format Stage String (UI Formatting)
+function formatStage(round) {
+	if (!round || round <= 0) return "-";
+	// Simple stage calculation (adjust if specific set logic is needed)
+	const stage = Math.max(1, Math.floor(round / 7) + 1); // Ensure stage is at least 1
+	const subStage = Math.max(1, (round % 7) + 1); // Ensure substage is at least 1
+	// Skip rendering for very early rounds if desired (e.g., before 2-1)
+	if (stage < 2) return "-";
+	return `${stage}-${subStage}`;
+}
+
+// Get Trait Chip Style (UI Styling)
+function getTraitChipStyle(style) {
+	switch (style) {
+		case 4:
+			return "bg-gradient-to-br from-purple-400 via-pink-500 to-yellow-400 text-white shadow-lg border border-purple-300/50"; // Prismatic
+		case 3:
+			return "bg-yellow-500/40 text-yellow-100 border border-yellow-500"; // Gold
+		case 2:
+			return "bg-gray-400/40 text-gray-100 border border-gray-400"; // Silver
+		case 1:
+			return "bg-[#cd7f32]/40 text-[#ffbf80] border border-[#cd7f32]"; // Bronze
+		default:
+			return "bg-black/30 text-gray-400 border border-gray-700"; // Inactive
+	}
+}
+
+// Get Placement Text Class (UI Styling)
+function getPlacementClass(placement) {
+	if (placement === 1) return "text-yellow-400 font-bold";
+	if (placement <= 4) return "text-sky-300";
+	return "text-gray-400";
+}
+
+// Get Ordinal Suffix (Unchanged Logic)
+function getOrdinal(n) {
+	const s = ["th", "st", "nd", "rd"];
+	const v = n % 100;
+	return n + (s[(v - 20) % 10] || s[v] || s[0]);
+}
+
+// Format Game Duration (UI Formatting)
+function formatGameDuration(seconds) {
+	if (seconds === null || seconds === undefined) return "-";
+	const minutes = Math.floor(seconds / 60);
+	const remainingSeconds = Math.floor(seconds % 60);
+	return `${minutes}m ${String(remainingSeconds).padStart(2, "0")}s`;
+}
+
+// --- Main Component ---
+
+export default function TFTMatchDetails({
+	matchDetails,
+	matchId,
+	summonerData, // Contains puuid of the viewing player
+}) {
+	// State
+	const [traitsData, setTraitsData] = useState({});
+	const [itemsData, setItemsData] = useState({});
+	const [championsData, setChampionsData] = useState({}); // Community Dragon data
+	const [augmentsData, setAugmentsData] = useState({}); // Augment data
+	const [dataDragonChampions, setDataDragonChampions] = useState({}); // Data Dragon data (for cost)
+	const [isDataLoaded, setIsDataLoaded] = useState(false);
+	const [playersData, setPlayersData] = useState({}); // Summoner names/tags
+
+	// Effect to Fetch Core TFT Data (Traits, Items, Champions, Augments)
+	useEffect(() => {
+		async function fetchTFTData() {
+			try {
+				// Fetch traits
+				const traitsResponse = await fetch(
+					"https://raw.communitydragon.org/latest/plugins/rcp-be-lol-game-data/global/default/v1/tfttraits.json"
+				);
+				const traitsJson = await traitsResponse.json();
+				const traitsMap = {};
+				traitsJson.forEach((trait) => {
+					if (trait?.trait_id) {
+						const key = trait.trait_id.toLowerCase();
+						traitsMap[key] = {
+							name: trait.name,
+							description: trait.desc,
+							iconPath: trait.icon_path,
+							effects: trait.effects || [],
+						};
+					}
+				});
+				setTraitsData(traitsMap);
+
+				// Fetch items
+				const itemsResponse = await fetch(
+					"https://raw.communitydragon.org/latest/plugins/rcp-be-lol-game-data/global/default/v1/tftitems.json"
+				);
+				const itemsJson = await itemsResponse.json();
+				const itemsMap = {};
+				itemsJson.forEach((item) => {
+					// Use iconData (more reliable path from CDragon JSON) or loadoutsIcon as fallback
+					const icon = item.iconData || item.loadoutsIcon || item.iconPath; // Prioritize iconData
+					if (item.id !== undefined)
+						itemsMap[item.id] = {
+							name: item.name,
+							description: item.desc,
+							iconPath: icon,
+						};
+					if (item.nameId)
+						itemsMap[item.nameId.toLowerCase()] = {
+							name: item.name,
+							description: item.desc,
+							iconPath: icon,
+						};
+				});
+				setItemsData(itemsMap);
+
+				// Fetch Community Dragon champions (Fallback source for name/traits)
+				const championsResponse = await fetch(
+					"https://raw.communitydragon.org/latest/plugins/rcp-be-lol-game-data/global/default/v1/tftchampions.json"
+				);
+				const championsJson = await championsResponse.json();
+				const championsMap = {};
+				championsJson.forEach((champion) => {
+					if (champion?.character_id) {
+						const key = champion.character_id.toLowerCase();
+						championsMap[key] = {
+							name: champion.name,
+							cost: champion.cost,
+							traits: champion.traits || [],
+							iconPath: champion.squareIconPath,
+						};
+					}
+				});
+				setChampionsData(championsMap);
+
+				// Fetch Data Dragon (Champions for Cost, Augments)
+				try {
+					const versionsResponse = await fetch(
+						"https://ddragon.leagueoflegends.com/api/versions.json"
+					);
+					const versions = await versionsResponse.json();
+					const latestVersion = versions[0]; // Get latest LoL patch version
+
+					// Fetch DDragon Champions (mainly for accurate tier/cost)
+					const dataDragonResponse = await fetch(
+						`https://ddragon.leagueoflegends.com/cdn/${latestVersion}/data/en_US/tft-champion.json`
+					);
+					const ddJson = await dataDragonResponse.json();
+					setDataDragonChampions(ddJson.data || {});
+
+					// Fetch DDragon Augments
+					const augmentResponse = await fetch(
+						`https://ddragon.leagueoflegends.com/cdn/${latestVersion}/data/en_US/tft-augments.json`
+					);
+					const augJson = await augmentResponse.json();
+					const augMap = {};
+					Object.values(augJson.data || {}).forEach((aug) => {
+						if (aug?.id)
+							augMap[aug.id.toLowerCase()] = {
+								name: aug.name,
+								desc: aug.desc,
+								iconPath: aug.icon,
+							};
+					});
+					setAugmentsData(augMap);
+				} catch (error) {
+					console.error("Error fetching Data Dragon data:", error);
+					// Handle error - potentially rely only on CDragon data
+				}
+
+				setIsDataLoaded(true);
+			} catch (error) {
+				console.error("Error fetching base TFT data:", error);
+				setIsDataLoaded(true); // Still set loaded to show error or partial data
+			}
+		}
+		fetchTFTData();
+	}, []);
+
+	// Effect to Fetch Player Names/Tags (Simulated - Adapt if you fetch this elsewhere)
+	useEffect(() => {
+		if (!matchDetails || !matchId) return;
+		const match = matchDetails.find((m) => m.metadata.match_id === matchId);
+		if (!match || !match.info?.participants) return;
+
+		const players = {};
+		match.info.participants.forEach((p) => {
+			if (p.puuid) {
+				// Use data directly from match if available, otherwise placeholder
+				players[p.puuid] = {
+					name: p.riotIdGameName || p.name || "Unknown",
+					tagLine: p.riotIdTagline || "", // May be empty string if unavailable
+				};
+			}
+		});
+		setPlayersData(players);
+	}, [matchDetails, matchId]);
+
+	// Helper to get Champion Cost (Uses Data Dragon first)
+	const getChampionCostFromDD = (characterId) => {
+		if (!characterId || !dataDragonChampions) return 0;
+		const lowerCaseId = characterId.toLowerCase();
+
+		// Attempt lookup using the full character ID (e.g., tft11_ahri) if available in DDragon keys
+		if (dataDragonChampions[lowerCaseId]) {
+			return dataDragonChampions[lowerCaseId].tier || 0;
+		}
+
+		// Fallback: Extract name part (e.g., "ahri") and try matching DDragon keys ending with it
+		const nameMatch = lowerCaseId.match(/tft\d+_(.+)/);
+		const championKeyPart = nameMatch ? nameMatch[1] : null; // Extracted name like "ahri"
+
+		if (championKeyPart) {
+			for (const key in dataDragonChampions) {
+				// Check if DDragon key (e.g., "TFT11_Ahri") ends with the extracted name part
+				// Case-insensitive comparison recommended
+				if (key.toLowerCase().endsWith(championKeyPart)) {
+					return dataDragonChampions[key].tier || 0;
+				}
+			}
+		}
+
+		// Final fallback to Community Dragon data (may be less accurate)
+		return championsData[lowerCaseId]?.cost || 0;
+	};
+
+	// --- Render Logic ---
+	if (!matchDetails || !matchId) {
+		return (
+			<div className="card-highlight p-6 text-center text-[--text-secondary]">
+				Loading...
+			</div>
+		);
+	}
+	const match = matchDetails.find((m) => m.metadata.match_id === matchId);
+
+	if (!match || !isDataLoaded) {
+		return (
+			<div className="card-highlight p-6 text-center">
+				<p className="text-[--text-secondary]">
+					{isDataLoaded ? "Match data not found." : "Loading match data..."}
+				</p>
+			</div>
+		);
+	}
+
+	const participants = match.info.participants || [];
+	participants.sort((a, b) => a.placement - b.placement); // Sort by placement
+
+	return (
+		<div className="card-highlight overflow-hidden shadow-xl">
+			{/* Optional Header */}
+			<div className="p-2 border-b border-gray-700/50 bg-black/20 flex justify-between items-center text-xs">
+				<div>
+					<span className="font-semibold mr-2">
+						{match.info.tft_game_type?.replace(/_/g, " ") || "Normal"}
+					</span>
+					<span className="text-gray-400">
+						{new Date(match.info.game_datetime).toLocaleDateString()}
+					</span>
+				</div>
+				<div className="text-gray-400">
+					Duration: {formatGameDuration(match.info.game_length)} • Set:{" "}
+					{match.info.tft_set_core_name ||
+						match.info.tft_set_number ||
+						"Unknown"}
+				</div>
+			</div>
+			{/* Table Header Row */}
+			<div className="flex items-center px-3 py-1.5 bg-black/30 text-xs font-semibold text-gray-400 border-b border-gray-700/50 sticky top-0 z-20">
+				<div className="w-[4%] text-center">#</div>
+				<div className="w-[16%] pl-1">Summoner</div>
+				<div className="w-[10%] pl-10">Stage</div>
+				<div className="w-[20%] pl-8">Synergies</div>
+				<div className="w-[40%] pl-40">Champions</div>
+				<div className="w-[10%] text-right pr-1">Stats</div>
+			</div>
+			{/* Participant Rows */}
+			<div className="divide-y divide-gray-700/30">
+				{participants.map((p, index) => (
+					<ParticipantRow
+						key={p.puuid || index}
+						participant={p}
+						traitsData={traitsData}
+						itemsData={itemsData}
+						championsData={championsData}
+						getChampionCostFromDD={getChampionCostFromDD}
+						isCurrentPlayer={p.puuid === summonerData?.puuid}
+						playerData={playersData[p.puuid]}
+						getTFTChampionImageUrl={getTFTChampionImageUrl}
+						mapCDragonAssetPath={mapCDragonAssetPath}
+					/>
+				))}
+			</div>
+		</div>
+	);
+}
+
+// --- Participant Row Component ---
+
+function ParticipantRow({
+	participant,
+	traitsData,
+	itemsData,
+	championsData, // CDragon data (names/fallback)
+	augmentsData,
+	getChampionCostFromDD,
+	isCurrentPlayer,
+	playerData,
+	getTFTChampionImageUrl, // Use the passed original function
+	mapCDragonAssetPath,
+}) {
+	// Sort units by cost (desc) then tier (desc)
+	const sortedUnits = [...(participant.units || [])].sort((a, b) => {
+		const costA = getChampionCostFromDD(a.character_id);
+		const costB = getChampionCostFromDD(b.character_id);
+		if (costB !== costA) return costB - costA;
+		return (b.tier || 0) - (a.tier || 0);
+	});
+
+	// Filter/sort active traits
+	const activeTraits = (participant.traits || [])
+		.filter((trait) => trait.style > 0 && traitsData[trait.name?.toLowerCase()])
+		.sort(
+			(a, b) =>
+				(b.style || 0) - (a.style || 0) ||
+				(b.num_units || 0) - (a.num_units || 0)
+		);
+
+	// Get augment IDs
+	const participantAugments = participant.augments || [];
+
+	// Get item IDs (preferring `items` array which usually holds numerical IDs)
+	const unitItemsSource = participant.items || []; // Use participant.items as the primary source
+
+	return (
+		<div
+			className={`flex items-stretch px-3 py-2 gap-2 text-sm ${
+				isCurrentPlayer ? "bg-blue-900/20" : ""
+			} hover:bg-gray-700/20 transition-colors duration-150 min-h-[60px]`}
+		>
+			{/* Placement */}
+			<div className="w-[4%] flex items-center justify-center text-center shrink-0">
+				<span className={`${getPlacementClass(participant.placement)} text-sm`}>
+					{participant.placement}
+				</span>
+			</div>
+
+			{/* Summoner */}
+			<div className="w-[16%] flex flex-col justify-center pl-1 shrink-0">
+				{/* Check if playerData exists before creating link */}
+				{playerData?.name ? (
+					<Link
+						href={`/profile/${encodeURIComponent(playerData.name)}/${
+							playerData.tagLine || "NA1"
+						}`}
+						legacyBehavior
+					>
+						<a
+							className="font-semibold text-gray-100 hover:text-blue-400 truncate"
+							title={`${playerData.name}#${playerData.tagLine}`}
+						>
+							{playerData.name}
+						</a>
+					</Link>
+				) : (
+					<span className="font-semibold text-gray-100 truncate">Unknown</span>
+				)}
+			</div>
+
+			{/* Stage */}
+			<div className="w-[10%] flex flex-col items-center justify-center text-center text-xs shrink-0">
+				<span className="font-medium text-gray-300">
+					{formatStage(participant.last_round)}
+				</span>
+				<span className="text-gray-400 text-[10px]">
+					{formatGameDuration(participant.time_eliminated)}
+				</span>
+			</div>
+
+			{/* Synergies (Traits) */}
+			<div className="w-[20%] flex flex-wrap items-center gap-0.5 pl-1 shrink-0">
+				{activeTraits.map((trait) => {
+					const traitInfo = traitsData[trait.name?.toLowerCase()];
+					if (!traitInfo) return null;
+					const cdnUrl = traitInfo.iconPath
+						? mapCDragonAssetPath(traitInfo.iconPath)
+						: null;
+					const traitStyle = getTraitChipStyle(trait.style);
+					const title = `${traitInfo.name} (${trait.num_units})\nStyle: ${
+						trait.style
+					}\n${traitInfo.description || ""}`;
+					return (
+						<div
+							key={trait.name}
+							className={`relative flex items-center justify-center w-4 h-4 rounded-sm ${traitStyle} p-0.5`}
+							title={title}
+						>
+							{cdnUrl ? (
+								<Image
+									src={cdnUrl}
+									alt=""
+									width={14}
+									height={14}
+									className="object-contain filter brightness-110 contrast-110"
+									unoptimized
+									onError={(e) => {
+										e.currentTarget.style.display = "none";
+									}}
+								/>
+							) : (
+								<span className="text-[7px] font-bold">?</span>
+							)}
+						</div>
+					);
+				})}
+			</div>
+
+			{/* Champions & Items */}
+			<div className="w-[40%] flex flex-wrap items-start gap-x-1 gap-y-0.5 pl-1 grow">
+				{sortedUnits.map((unit, idx) => {
+					const championCost = getChampionCostFromDD(unit.character_id);
+					const borderColor = getBorderColorForCost(championCost);
+					const starColor = getStarColorForCost(championCost);
+					const champName =
+						championsData[unit.character_id?.toLowerCase()]?.name ||
+						unit.character_id?.split("_")[1] ||
+						"Unknown";
+					// Use the passed original function for the champion image URL
+					const cdnUrl = getTFTChampionImageUrl(unit.character_id, champName);
+					// Get item IDs for this unit (ensure it's an array)
+					const unitItems = unit.items || [];
+
+					return (
+						<div
+							key={`${unit.character_id}-${idx}`}
+							className="flex flex-col items-center relative w-8"
+							title={champName}
+						>
+							{/* Stars */}
+							<div className="flex h-2 -mb-0.5 z-10">
+								{Array.from({ length: unit.tier || 0 }).map((_, i) => (
+									<FaStar
+										key={i}
+										className={`w-1.5 h-1.5 ${starColor}`}
+										style={{ filter: "drop-shadow(0 0 1px black)" }}
+									/>
+								))}
+							</div>
+							{/* Champion Icon */}
+							<div
+								className={`relative bg-gray-900 rounded w-8 h-8 flex items-center justify-center overflow-hidden border ${borderColor}`}
+							>
+								{cdnUrl ? (
+									<Image
+										src={cdnUrl}
+										alt=""
+										width={32}
+										height={32}
+										className="object-cover scale-105"
+										unoptimized
+										title={champName}
+										onError={(e) => {
+											e.currentTarget.style.display = "none";
+											const fallback = e.currentTarget
+												.closest("div")
+												.querySelector(".fallback-text");
+											if (fallback) fallback.style.display = "flex";
+										}}
+									/>
+								) : (
+									<div className="absolute inset-0 flex items-center justify-center text-xs text-gray-400">
+										?
+									</div>
+								)}
+								<div className="fallback-text hidden absolute inset-0 items-center justify-center text-[8px] font-semibold text-white bg-gray-700/80">
+									{champName?.substring(0, 3) || "?"}
+								</div>
+							</div>
+							{/* Items */}
+							<div className="flex justify-center items-center mt-0.5 h-3 space-x-0.5">
+								{unitItems.slice(0, 3).map((itemIdentifier, itemIdx) => {
+									// Assume itemIdentifier is a numerical ID
+									const item = itemsData[itemIdentifier];
+									// Construct URL using the mapped iconPath (which uses iconData/loadoutsIcon)
+									const itemCdnUrl = item?.iconPath
+										? `https://raw.communitydragon.org/latest/game/${item.iconPath
+												?.toLowerCase()
+												.replace(".dds", ".png")}`
+										: null;
+									const itemName = item?.name || `Item ID: ${itemIdentifier}`;
+									const itemDesc = item?.description || "";
+									const itemTitle = `${itemName}\n\n${itemDesc.replace(
+										/<[^>]*>?/gm,
+										""
+									)}`; // Basic HTML strip for tooltip
+
+									return (
+										<div
+											key={`${itemIdentifier}-${itemIdx}`}
+											className="w-3 h-3 bg-black/50 rounded-sm overflow-hidden relative border border-black/50"
+											title={itemTitle}
+										>
+											{itemCdnUrl ? (
+												<Image
+													src={itemCdnUrl}
+													alt=""
+													width={12}
+													height={12}
+													className="object-contain"
+													unoptimized
+													onError={(e) => {
+														e.currentTarget.style.opacity = "0.3";
+													}}
+												/>
+											) : (
+												<div className="w-full h-full flex items-center justify-center text-[7px] text-gray-500">
+													?
+												</div>
+											)}
+										</div>
+									);
+								})}
+								{/* Render empty slots */}
+								{Array.from({ length: 3 - unitItems.length }).map((_, i) => (
+									<div
+										key={`empty-${i}`}
+										className="w-3 h-3 bg-black/20 rounded-sm border border-black/30"
+									></div>
+								))}
+							</div>
+						</div>
+					);
+				})}
+			</div>
+
+			{/* Stats */}
+			<div className="w-[10%] flex flex-col items-end justify-center text-right pr-1 text-xs space-y-0.5 shrink-0">
+				<div
+					className="flex items-center gap-1"
+					title="Damage Dealt to Players"
+				>
+					<FaBolt className="text-purple-400 w-2.5 h-2.5" />
+					<span className="text-[10px]">
+						{participant.total_damage_to_players || 0}
+					</span>
+				</div>
+				<div className="flex items-center gap-1" title="Gold Left">
+					<FaCoins className="text-yellow-400 w-2.5 h-2.5" />
+					<span className="text-[10px]">{participant.gold_left || 0}</span>
+				</div>
+				<div className="flex items-center gap-1" title="Players Eliminated">
+					<FaSkull className="text-gray-400 w-2.5 h-2.5" />
+					<span className="text-[10px]">
+						{participant.players_eliminated || 0}
+					</span>
+				</div>
+			</div>
+		</div>
+	);
+}


### PR DESCRIPTION
This pull request includes enhancements to the `TFTMatchHistory` component and the addition of new CSS animations. The most important changes include adding expand/collapse functionality to match cards, updating image attributes for better performance, and introducing a new fade-in animation.

Enhancements to `TFTMatchHistory` component:

* [`src/components/tft/MatchHistory.js`](diffhunk://#diff-fd738735f0969dd4bdbc708ba9e0cd254333a30cc09c05c43fa510008a563d70L3-R11): Added `FaChevronDown` and `FaChevronUp` icons for expand/collapse functionality and implemented state management for expanded match details. [[1]](diffhunk://#diff-fd738735f0969dd4bdbc708ba9e0cd254333a30cc09c05c43fa510008a563d70L3-R11) [[2]](diffhunk://#diff-fd738735f0969dd4bdbc708ba9e0cd254333a30cc09c05c43fa510008a563d70R94-R95) [[3]](diffhunk://#diff-fd738735f0969dd4bdbc708ba9e0cd254333a30cc09c05c43fa510008a563d70R309-R314) [[4]](diffhunk://#diff-fd738735f0969dd4bdbc708ba9e0cd254333a30cc09c05c43fa510008a563d70R572-R592)

Performance improvements:

* [`src/components/tft/MatchHistory.js`](diffhunk://#diff-fd738735f0969dd4bdbc708ba9e0cd254333a30cc09c05c43fa510008a563d70L351-R373): Updated `Image` components to use `width` and `height` attributes instead of deprecated `layout` and `objectFit` properties. [[1]](diffhunk://#diff-fd738735f0969dd4bdbc708ba9e0cd254333a30cc09c05c43fa510008a563d70L351-R373) [[2]](diffhunk://#diff-fd738735f0969dd4bdbc708ba9e0cd254333a30cc09c05c43fa510008a563d70L411-R431) [[3]](diffhunk://#diff-fd738735f0969dd4bdbc708ba9e0cd254333a30cc09c05c43fa510008a563d70L452-R473) [[4]](diffhunk://#diff-fd738735f0969dd4bdbc708ba9e0cd254333a30cc09c05c43fa510008a563d70L482-R504)

New CSS animations:

* [`src/app/globals.css`](diffhunk://#diff-4f206759c961f544a48464ad2ee231adc87e72593d03a0004b68c17771f7a412R183-R186): Added `.animate-fadeIn` class and `@keyframes fadeIn` for fade-in animation effect. [[1]](diffhunk://#diff-4f206759c961f544a48464ad2ee231adc87e72593d03a0004b68c17771f7a412R183-R186) [[2]](diffhunk://#diff-4f206759c961f544a48464ad2ee231adc87e72593d03a0004b68c17771f7a412R213-R223)