### PR TITLE
fix(tft): update image source handling in ParticipantRow

### DIFF
--- a/src/components/tft/MatchDetails.js
+++ b/src/components/tft/MatchDetails.js
@@ -526,7 +526,7 @@ function ParticipantRow({
 							>
 								{cdnUrl ? (
 									<Image
-										src={cdnUrl.primary}
+										src={typeof cdnUrl === "object" ? cdnUrl.primary : cdnUrl}
 										alt=""
 										width={32}
 										height={32}
@@ -534,11 +534,16 @@ function ParticipantRow({
 										unoptimized
 										title={champName}
 										onError={(e) => {
-											e.currentTarget.style.display = "none";
-											const fallback = e.currentTarget
-												.closest("div")
-												.querySelector(".fallback-text");
-											if (fallback) fallback.style.display = "flex";
+											// Try fallback URL if available
+											if (typeof cdnUrl === "object" && cdnUrl.fallback) {
+												e.currentTarget.src = cdnUrl.fallback;
+											} else {
+												e.currentTarget.style.display = "none";
+												const fallback = e.currentTarget
+													.closest("div")
+													.querySelector(".fallback-text");
+												if (fallback) fallback.style.display = "flex";
+											}
 										}}
 									/>
 								) : (


### PR DESCRIPTION
This pull request includes an update to the `ParticipantRow` component in the `MatchDetails.js` file to improve how image URLs are handled. The most important changes include adding a fallback mechanism for image URLs and updating the `src` attribute assignment.

Improvements to image URL handling:

* [`src/components/tft/MatchDetails.js`](diffhunk://#diff-2ac5766fe46a4311b6d94fb6c732fd14b4bf6c6093674b53bdba5f5356a4124aL529-R546): Modified the `src` attribute to handle both string and object types for `cdnUrl`. Added a fallback mechanism to use a secondary URL if the primary URL fails to load.