### PR TITLE
[ClutchGG] [TFT] Future Proof Images Per TFT Set

### DIFF
--- a/src/components/tft/MatchDetails.js
+++ b/src/components/tft/MatchDetails.js
@@ -23,11 +23,11 @@ function mapCDragonAssetPath(jsonPath) {
 	return `https://raw.communitydragon.org/latest/plugins/rcp-be-lol-game-data/global/default${lower}`;
 }
 
-// Get Champion Image URL with Set 13 fallback for Set 14
+// Get Champion Image URL using the /game/ path with primary/fallback
 function getTFTChampionImageUrl(characterId, championName) {
 	if (!characterId) return null;
 
-	// Skip loading images for special units like "summon" to prevent infinite loops
+	// Skip loading images for special units like "summon"
 	if (characterId.toLowerCase().includes("_summon")) {
 		return null;
 	}
@@ -36,23 +36,23 @@ function getTFTChampionImageUrl(characterId, championName) {
 	const match = characterId.match(/TFT(\d+)/i);
 	if (match && match[1]) {
 		setNumber = parseInt(match[1]);
+	} else {
+		// Cannot determine set number from characterId, return null or a placeholder
+		return null;
 	}
+
 	let championBaseName = characterId.split("_")[1];
-	if (!championBaseName) return null;
+	if (!championBaseName) return null; // Cannot determine base name
 	championBaseName = championBaseName.toLowerCase();
 
-	// Dynamic image URLs for different sets with correct paths
-	if (setNumber === 14) {
-		return {
-			primary: `https://raw.communitydragon.org/latest/plugins/rcp-be-lol-game-data/global/default/assets/characters/tft${setNumber}_${championBaseName}/hud/tft${setNumber}_${championBaseName}_square.tft_set${setNumber}.jpg`,
-			fallback: `https://raw.communitydragon.org/latest/game/assets/characters/tft13_${championBaseName}/hud/tft13_${championBaseName}_square.tft_set13.png`,
-		};
-	}
-	if (setNumber === 13) {
-		return `https://raw.communitydragon.org/latest/game/assets/characters/tft13_${championBaseName}/hud/tft13_${championBaseName}_square.tft_set13.png`;
-	}
-	// Default fallback for other sets
-	return `https://raw.communitydragon.org/latest/plugins/rcp-be-lol-game-data/global/default/assets/characters/tft${setNumber}_${championBaseName}/hud/tft${setNumber}_${championBaseName}_square.tft_set${setNumber}.png`;
+	// Use the consistent /game/ path
+	const basePath = `https://raw.communitydragon.org/latest/game/assets/characters/tft${setNumber}_${championBaseName}/hud/tft${setNumber}_${championBaseName}_square`;
+
+	// Return primary (.tft_setX.png) and fallback (.png) URLs
+	return {
+		primary: `${basePath}.tft_set${setNumber}.png`,
+		fallback: `${basePath}.png`,
+	};
 }
 
 // Get border color based on champion cost
@@ -613,15 +613,32 @@ function ParticipantRow({
 										unoptimized
 										title={champName}
 										onError={(e) => {
-											// Try fallback URL if available
-											if (typeof cdnUrl === "object" && cdnUrl.fallback) {
-												e.currentTarget.src = cdnUrl.fallback;
-											} else {
-												e.currentTarget.style.display = "none";
-												const fallback = e.currentTarget
+											const imageElement = e.currentTarget;
+											// Check if the source is already the fallback URL
+											if (
+												typeof cdnUrl === "object" &&
+												cdnUrl.fallback &&
+												imageElement.src === cdnUrl.fallback
+											) {
+												// Fallback has already been tried and failed
+												imageElement.style.display = "none"; // Hide the broken image
+												const fallbackText = imageElement
 													.closest("div")
 													.querySelector(".fallback-text");
-												if (fallback) fallback.style.display = "flex";
+												if (fallbackText) fallbackText.style.display = "flex"; // Show text placeholder
+											} else if (
+												typeof cdnUrl === "object" &&
+												cdnUrl.fallback
+											) {
+												// Primary failed, try the fallback URL
+												imageElement.src = cdnUrl.fallback;
+											} else {
+												// Primary failed and there is no fallback URL (or cdnUrl wasn't an object)
+												imageElement.style.display = "none"; // Hide the broken image
+												const fallbackText = imageElement
+													.closest("div")
+													.querySelector(".fallback-text");
+												if (fallbackText) fallbackText.style.display = "flex"; // Show text placeholder
 											}
 										}}
 									/>

--- a/src/components/tft/TopUnits.js
+++ b/src/components/tft/TopUnits.js
@@ -10,11 +10,11 @@ function mapCDragonAssetPath(jsonPath) {
 	return `https://raw.communitydragon.org/latest/plugins/rcp-be-lol-game-data/global/default${lower}`;
 }
 
-// Function to generate TFT champion URL based on character ID with Set 13 fallback
+// Function to generate TFT champion URL based on character ID using the /game/ path
 function getTFTChampionImageUrl(characterId, championName) {
 	if (!characterId) return null;
 
-	// Skip loading images for special units like "summon" to prevent infinite loops
+	// Skip loading images for special units like "summon"
 	if (characterId.toLowerCase().includes("_summon")) {
 		return null;
 	}
@@ -23,23 +23,23 @@ function getTFTChampionImageUrl(characterId, championName) {
 	const match = characterId.match(/TFT(\d+)/i);
 	if (match && match[1]) {
 		setNumber = parseInt(match[1]);
+	} else {
+		// Cannot determine set number from characterId, return null or a placeholder
+		return null;
 	}
+
 	let championBaseName = characterId.split("_")[1];
-	if (!championBaseName) return null;
+	if (!championBaseName) return null; // Cannot determine base name
 	championBaseName = championBaseName.toLowerCase();
 
-	// Dynamic image URLs for different sets with correct paths
-	if (setNumber === 14) {
-		return {
-			primary: `https://raw.communitydragon.org/latest/plugins/rcp-be-lol-game-data/global/default/assets/characters/tft${setNumber}_${championBaseName}/hud/tft${setNumber}_${championBaseName}_square.tft_set${setNumber}.jpg`,
-			fallback: `https://raw.communitydragon.org/latest/game/assets/characters/tft13_${championBaseName}/hud/tft13_${championBaseName}_square.tft_set13.png`,
-		};
-	}
-	if (setNumber === 13) {
-		return `https://raw.communitydragon.org/latest/game/assets/characters/tft13_${championBaseName}/hud/tft13_${championBaseName}_square.tft_set13.png`;
-	}
-	// Default fallback for other sets
-	return `https://raw.communitydragon.org/latest/plugins/rcp-be-lol-game-data/global/default/assets/characters/tft${setNumber}_${championBaseName}/hud/tft${setNumber}_${championBaseName}_square.tft_set${setNumber}.png`;
+	// Use the consistent /game/ path
+	const basePath = `https://raw.communitydragon.org/latest/game/assets/characters/tft${setNumber}_${championBaseName}/hud/tft${setNumber}_${championBaseName}_square`;
+
+	// Return primary (.tft_setX.png) and fallback (.png) URLs
+	return {
+		primary: `${basePath}.tft_set${setNumber}.png`,
+		fallback: `${basePath}.png`,
+	};
 }
 
 // Cost-based color mapping for unit borders
@@ -408,14 +408,32 @@ export default function TopUnits({ matchDetails, summonerData }) {
 											className="object-cover"
 											unoptimized
 											onError={(e) => {
-												// Try fallback URL if available
-												if (typeof cdnUrl === "object" && cdnUrl.fallback) {
-													e.currentTarget.src = cdnUrl.fallback;
+												const imageElement = e.currentTarget;
+												// Check if the source is already the fallback URL
+												if (
+													typeof cdnUrl === "object" &&
+													cdnUrl.fallback &&
+													imageElement.src === cdnUrl.fallback
+												) {
+													// Fallback has already been tried and failed
+													imageElement.style.display = "none"; // Hide the broken image
+													const fallbackText = imageElement
+														.closest("div")
+														.querySelector(".fallback-text");
+													if (fallbackText) fallbackText.style.display = "flex"; // Show text placeholder
+												} else if (
+													typeof cdnUrl === "object" &&
+													cdnUrl.fallback
+												) {
+													// Primary failed, try the fallback URL
+													imageElement.src = cdnUrl.fallback;
 												} else {
-													// If no fallback or fallback also failed, show text fallback
-													e.currentTarget.style.display = "none";
-													const fallback = e.currentTarget.nextElementSibling;
-													if (fallback) fallback.style.display = "flex";
+													// Primary failed and there is no fallback URL (or cdnUrl wasn't an object)
+													imageElement.style.display = "none"; // Hide the broken image
+													const fallbackText = imageElement
+														.closest("div")
+														.querySelector(".fallback-text");
+													if (fallbackText) fallbackText.style.display = "flex"; // Show text placeholder
 												}
 											}}
 										/>


### PR DESCRIPTION
This pull request refactors the logic for generating and handling TFT champion image URLs across multiple components (`MatchDetails.js`, `MatchHistory.js`, and `TopUnits.js`). It introduces a consistent URL path structure, improves fallback handling for broken images, and enhances clarity in the codebase.

### URL Path Refactoring
* Updated `getTFTChampionImageUrl` to use a consistent `/game/` path for champion image URLs, replacing the older paths and removing hardcoded fallbacks for Set 13. The function now dynamically generates URLs for both primary and fallback images. [[1]](diffhunk://#diff-2ac5766fe46a4311b6d94fb6c732fd14b4bf6c6093674b53bdba5f5356a4124aR39-L56) [[2]](diffhunk://#diff-fd738735f0969dd4bdbc708ba9e0cd254333a30cc09c05c43fa510008a563d70R37-L54) [[3]](diffhunk://#diff-4db132ea8ba1473cc98125c3e14e65631fd0d6bad7d31c5d2e6e031f6f72e5c1R26-L43)

### Improved Fallback Handling for Broken Images
* Enhanced the `onError` handlers in `ParticipantRow`, `TFTMatchHistory`, and `TopUnits` to:
  - Check if the fallback URL has already been tried.
  - Hide broken images and display a text placeholder if both primary and fallback URLs fail. [[1]](diffhunk://#diff-2ac5766fe46a4311b6d94fb6c732fd14b4bf6c6093674b53bdba5f5356a4124aL616-R641) [[2]](diffhunk://#diff-fd738735f0969dd4bdbc708ba9e0cd254333a30cc09c05c43fa510008a563d70L555-R582) [[3]](diffhunk://#diff-4db132ea8ba1473cc98125c3e14e65631fd0d6bad7d31c5d2e6e031f6f72e5c1L411-R436)

### Code Simplification and Clarity
* Removed outdated comments and clarified existing ones, such as eliminating references to Set 13 fallback logic and adding explanations for new behaviors (e.g., placeholder handling when `characterId` or `championBaseName` is invalid). [[1]](diffhunk://#diff-2ac5766fe46a4311b6d94fb6c732fd14b4bf6c6093674b53bdba5f5356a4124aL26-R30) [[2]](diffhunk://#diff-fd738735f0969dd4bdbc708ba9e0cd254333a30cc09c05c43fa510008a563d70L24-R28) [[3]](diffhunk://#diff-4db132ea8ba1473cc98125c3e14e65631fd0d6bad7d31c5d2e6e031f6f72e5c1L13-R17)