### PR TITLE
[ClutchGG] [LoL] Some Item Images Not Showing

### DIFF
--- a/src/components/league/MatchHistory.js
+++ b/src/components/league/MatchHistory.js
@@ -874,7 +874,7 @@ const MatchHistory = ({
 													<div key={idx} className="flex items-center">
 														{itemId > 0 ? (
 															<Image
-																src={`https://ddragon.leagueoflegends.com/cdn/15.6.1/img/item/${itemId}.png`}
+																src={`https://ddragon.leagueoflegends.com/cdn/15.8.1/img/item/${itemId}.png`}
 																alt="Item"
 																width={28}
 																height={28}
@@ -894,7 +894,7 @@ const MatchHistory = ({
 												{items[6] > 0 ? (
 													<div className="flex items-center">
 														<Image
-															src={`https://ddragon.leagueoflegends.com/cdn/15.6.1/img/item/${items[6]}.png`}
+															src={`https://ddragon.leagueoflegends.com/cdn/15.8.1/img/item/${items[6]}.png`}
 															alt="Ward"
 															width={28}
 															height={28}
@@ -914,7 +914,7 @@ const MatchHistory = ({
 													<div key={idx} className="flex items-center">
 														{itemId > 0 ? (
 															<Image
-																src={`https://ddragon.leagueoflegends.com/cdn/15.6.1/img/item/${itemId}.png`}
+																src={`https://ddragon.leagueoflegends.com/cdn/15.8.1/img/item/${itemId}.png`}
 																alt="Item"
 																width={28}
 																height={28}

--- a/src/components/league/MatchStatsTab.js
+++ b/src/components/league/MatchStatsTab.js
@@ -80,7 +80,7 @@ export default function MatchStatsTab({
 					const itemId = p[`item${i}`];
 					if (itemId && itemId > 0) {
 						toPrefetch.push(
-							`https://ddragon.leagueoflegends.com/cdn/15.6.1/img/item/${itemId}.png`
+							`https://ddragon.leagueoflegends.com/cdn/15.8.1/img/item/${itemId}.png`
 						);
 					}
 				}
@@ -583,7 +583,7 @@ function Participant({ p, puuid, r, getA, getPerk, arena = false }) {
 									>
 										{itemId > 0 ? (
 											<NextImage
-												src={`https://ddragon.leagueoflegends.com/cdn/15.6.1/img/item/${itemId}.png`}
+												src={`https://ddragon.leagueoflegends.com/cdn/15.8.1/img/item/${itemId}.png`}
 												alt={`Item ${itemId}`}
 												width={24}
 												height={24}
@@ -600,7 +600,7 @@ function Participant({ p, puuid, r, getA, getPerk, arena = false }) {
 							<div className="w-6 h-6 bg-[--card-bg] rounded overflow-hidden">
 								{p.item6 > 0 ? (
 									<NextImage
-										src={`https://ddragon.leagueoflegends.com/cdn/15.6.1/img/item/${p.item6}.png`}
+										src={`https://ddragon.leagueoflegends.com/cdn/15.8.1/img/item/${p.item6}.png`}
 										alt={`Item ${p.item6}`}
 										width={24}
 										height={24}
@@ -621,7 +621,7 @@ function Participant({ p, puuid, r, getA, getPerk, arena = false }) {
 									>
 										{itemId > 0 ? (
 											<NextImage
-												src={`https://ddragon.leagueoflegends.com/cdn/15.6.1/img/item/${itemId}.png`}
+												src={`https://ddragon.leagueoflegends.com/cdn/15.8.1/img/item/${itemId}.png`}
 												alt={`Item ${itemId}`}
 												width={24}
 												height={24}


### PR DESCRIPTION
This pull request updates the item image URLs in the `MatchHistory` and `MatchStatsTab` components to use the latest version of the Data Dragon API (15.8.1). This ensures that the application displays the most up-to-date item images for League of Legends.

### Updates to Data Dragon API version:

* [`src/components/league/MatchHistory.js`](diffhunk://#diff-dc4ba1319a22fd44b1dc89425f71add01e214115c7f9b7d23703ac01cb155b8fL877-R877): Updated item image URLs in three instances to use version `15.8.1` of the Data Dragon API. [[1]](diffhunk://#diff-dc4ba1319a22fd44b1dc89425f71add01e214115c7f9b7d23703ac01cb155b8fL877-R877) [[2]](diffhunk://#diff-dc4ba1319a22fd44b1dc89425f71add01e214115c7f9b7d23703ac01cb155b8fL897-R897) [[3]](diffhunk://#diff-dc4ba1319a22fd44b1dc89425f71add01e214115c7f9b7d23703ac01cb155b8fL917-R917)
* [`src/components/league/MatchStatsTab.js`](diffhunk://#diff-e793472394edd62369ac2c2b7d49e5bb484cb3fc2ae2c2b7b1a00d5a6a43f0daL83-R83): Updated item image URLs in three instances and prefetch logic to use version `15.8.1` of the Data Dragon API. [[1]](diffhunk://#diff-e793472394edd62369ac2c2b7d49e5bb484cb3fc2ae2c2b7b1a00d5a6a43f0daL83-R83) [[2]](diffhunk://#diff-e793472394edd62369ac2c2b7d49e5bb484cb3fc2ae2c2b7b1a00d5a6a43f0daL586-R586) [[3]](diffhunk://#diff-e793472394edd62369ac2c2b7d49e5bb484cb3fc2ae2c2b7b1a00d5a6a43f0daL603-R603) [[4]](diffhunk://#diff-e793472394edd62369ac2c2b7d49e5bb484cb3fc2ae2c2b7b1a00d5a6a43f0daL624-R624)