### PR TITLE
ClutchGG.LOL v2.1.6

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -15,7 +15,7 @@ COPY --from=deps /app/node_modules ./node_modules
 COPY . .
 
 # Set environment variable
-ENV NEXT_TELEMETRY_DISABLED 1
+ENV NEXT_TELEMETRY_DISABLED=1
 
 # Build application
 RUN npm run build
@@ -24,8 +24,8 @@ RUN npm run build
 FROM node:20-alpine AS runner
 WORKDIR /app
 
-ENV NODE_ENV production
-ENV NEXT_TELEMETRY_DISABLED 1
+ENV NODE_ENV=production
+ENV NEXT_TELEMETRY_DISABLED=1
 
 RUN addgroup --system --gid 1001 nodejs
 RUN adduser --system --uid 1001 nextjs
@@ -44,7 +44,7 @@ USER nextjs
 
 EXPOSE 3000
 
-ENV PORT 3000
-ENV HOSTNAME "0.0.0.0"
+ENV PORT=3000
+ENV HOSTNAME="0.0.0.0"
 
 CMD ["node", "server.js"]

--- a/src/app/api/tft/leaderboard/route.js
+++ b/src/app/api/tft/leaderboard/route.js
@@ -1,6 +1,6 @@
 import { NextResponse } from "next/server";
 import { fetchTFTSummonerPUUID } from "@/lib/tft/tftApi";
-import { fetchAccountDataByPUUID } from "@/lib/league/leagueApi";
+import { fetchAccountDataByPUUID } from "@/lib/league/leagueApi"; // Re-use League's account fetcher
 
 const TFT_API_KEY = process.env.TFT_API_KEY;
 
@@ -10,9 +10,12 @@ async function fetchWithRetry(fn, args, retries = 1) {
 		return await fn(...args);
 	} catch (error) {
 		if (retries > 0) {
-			return await fetchWithRetry(fn, args, retries - 1);
+			console.warn(`Retrying ${fn.name} after error: ${error.message}`);
+			await new Promise((resolve) => setTimeout(resolve, 500)); // Wait 500ms before retry
+			return fetchWithRetry(fn, args, retries - 1);
 		}
-		throw error;
+		console.error(`Failed ${fn.name} after multiple retries:`, error);
+		throw error; // Re-throw the error after retries are exhausted
 	}
 }
 
@@ -20,32 +23,64 @@ export async function GET(req) {
 	const { searchParams } = new URL(req.url);
 	const tier = searchParams.get("tier") || "CHALLENGER";
 	const division = searchParams.get("division") || "I";
-	const region = searchParams.get("region") || "euw1";
+	const region = searchParams.get("region") || "euw1"; // Default to EUW1
+
+	if (!TFT_API_KEY) {
+		return NextResponse.json(
+			{ error: "TFT API key is not configured." },
+			{ status: 500 }
+		);
+	}
 
 	// Construct API URL based on tier
 	let apiUrl;
-	if (["MASTER", "GRANDMASTER", "CHALLENGER"].includes(tier.toUpperCase())) {
-		// For higher tiers, use the specific endpoints
+	const upperTier = tier.toUpperCase();
+	if (["MASTER", "GRANDMASTER", "CHALLENGER"].includes(upperTier)) {
+		// For higher tiers, use the specific endpoints (no division needed)
 		apiUrl = `https://${region}.api.riotgames.com/tft/league/v1/${tier.toLowerCase()}`;
 	} else {
 		// For lower tiers (IRON to DIAMOND), use the entries endpoint
-		apiUrl = `https://${region}.api.riotgames.com/tft/league/v1/entries/${tier}/${division}?page=1`;
+		// Ensure division is valid (I, II, III, IV) - default to I if invalid
+		const validDivision = ["I", "II", "III", "IV"].includes(
+			division.toUpperCase()
+		)
+			? division.toUpperCase()
+			: "I";
+		apiUrl = `https://${region}.api.riotgames.com/tft/league/v1/entries/${upperTier}/${validDivision}?page=1`; // Assuming page 1 is sufficient for top 100
 	}
 
 	try {
 		const response = await fetch(apiUrl, {
 			headers: { "X-Riot-Token": TFT_API_KEY },
+			next: { revalidate: 300 }, // Cache for 5 minutes
 		});
 
 		if (!response.ok) {
-			return NextResponse.json([], { status: 200 });
+			// Handle specific rate limit error
+			if (response.status === 429) {
+				console.error("TFT API rate limit exceeded.");
+				return NextResponse.json(
+					{ error: "Rate limit exceeded. Please try again later." },
+					{ status: 429 }
+				);
+			}
+			// Handle other errors
+			console.error(
+				`TFT API error: ${response.status} - ${response.statusText}`
+			);
+			return NextResponse.json(
+				{
+					error: `Failed to fetch leaderboard data from Riot API (${response.status})`,
+				},
+				{ status: response.status }
+			);
 		}
 
 		let rawData = await response.json();
 		let leaderboardData = [];
 
 		// Handle the different response formats based on tier
-		if (["MASTER", "GRANDMASTER", "CHALLENGER"].includes(tier.toUpperCase())) {
+		if (["MASTER", "GRANDMASTER", "CHALLENGER"].includes(upperTier)) {
 			// Higher tiers return an object with entries array
 			leaderboardData = rawData.entries || [];
 		} else {
@@ -54,44 +89,57 @@ export async function GET(req) {
 		}
 
 		if (leaderboardData.length === 0) {
-			return NextResponse.json([]);
+			return NextResponse.json([]); // Return empty array if no players found
 		}
 
 		// Sort by leaguePoints in descending order
 		leaderboardData.sort((a, b) => b.leaguePoints - a.leaguePoints);
 
-		// Take only top 100 entries
+		// Take only top 100 entries (Riot API might return more for lower tiers)
 		leaderboardData = leaderboardData.slice(0, 100);
 
+		// Enrich with profile data (gameName, tagLine, profileIconId)
 		const detailedResults = await Promise.allSettled(
 			leaderboardData.map(async (entry) => {
+				// Need summonerId for TFT PUUID fetch
+				if (!entry.summonerId) {
+					console.warn("Skipping entry due to missing summonerId:", entry);
+					return { ...entry, profileData: null }; // Skip if no summonerId
+				}
 				try {
+					// Fetch PUUID using summonerId (TFT specific)
 					const { puuid, profileIconId } = await fetchWithRetry(
 						fetchTFTSummonerPUUID,
 						[entry.summonerId, region],
-						1
+						1 // Retry once
 					);
-					// Use the shared account data endpoint since it's game-agnostic
+
+					// Fetch account data using PUUID (Game Agnostic)
 					const accountData = await fetchWithRetry(
 						fetchAccountDataByPUUID,
-						[puuid],
-						1
+						[puuid], // Pass PUUID as an array
+						1 // Retry once
 					);
+
 					return {
 						...entry,
 						profileData: {
 							gameName: accountData.gameName,
 							tagLine: accountData.tagLine,
-							profileIconId,
+							profileIconId: profileIconId, // Use icon from TFT summoner endpoint
 						},
 					};
 				} catch (error) {
-					// Suppressing enrichment error messages, returning fallback data instead.
+					console.error(
+						`Error enriching data for summonerId ${entry.summonerId}:`,
+						error.message
+					);
+					// Return entry with fallback profile data on error
 					return {
 						...entry,
 						profileData: {
-							gameName: "Unknown",
-							tagLine: "Unknown",
+							gameName: entry.summonerName || "Unknown", // Fallback to summonerName if available
+							tagLine: "error",
 							profileIconId: null,
 						},
 					};
@@ -99,14 +147,17 @@ export async function GET(req) {
 			})
 		);
 
-		const detailedData = detailedResults.map((result) =>
-			result.status === "fulfilled" ? result.value : {}
-		);
+		// Filter out rejected promises and extract values
+		const enrichedData = detailedResults
+			.filter((result) => result.status === "fulfilled" && result.value)
+			.map((result) => result.value);
 
-		return NextResponse.json(detailedData, {
-			headers: { "Cache-Control": "s-maxage=60, stale-while-revalidate" },
-		});
+		return NextResponse.json(enrichedData);
 	} catch (error) {
-		return NextResponse.json([], { status: 200 });
+		console.error("Error fetching or processing TFT leaderboard:", error);
+		return NextResponse.json(
+			{ error: "Internal server error fetching leaderboard data." },
+			{ status: 500 }
+		);
 	}
 }

--- a/src/components/league/SeasonRanks.js
+++ b/src/components/league/SeasonRanks.js
@@ -149,8 +149,9 @@ const SeasonRanks = ({
 
 	if (isLoading && rankHistory.length === 0) {
 		return (
-			<div className="card-highlight text-center py-6">
-				<div className="loading-spinner mx-auto"></div>
+			// Center the loading spinner and text vertically and horizontally
+			<div className="card-highlight flex flex-col items-center justify-center py-6 min-h-[100px]">
+				<div className="loading-spinner"></div>
 				<p className="text-[--text-secondary] mt-4">Loading rank history...</p>
 			</div>
 		);
@@ -222,18 +223,24 @@ const SeasonRanks = ({
 						{rankHistory.map((rank, index) => (
 							<div
 								key={index}
-								className="flex items-center py-1.5 border-b border-[--card-border] last:border-b-0"
+								// Use flexbox to align items and justify-between to push LP to the right
+								className="flex items-center justify-between py-1.5 border-b border-[--card-border] last:border-b-0"
 							>
-								<div className="flex items-center gap-2 flex-1">
-									{/* Season */}
-									<div className="bg-[--card-bg] text-[--text-secondary] text-xs font-semibold py-0.5 px-2 rounded-md min-w-[50px] text-center">
+								{/* Left side: Season and Rank */}
+								<div className="flex items-center gap-2 flex-grow">
+									{/* Season - Fixed width for alignment */}
+									<div className="bg-[--card-bg] text-[--text-secondary] text-xs font-semibold py-0.5 px-2 rounded-md w-[60px] text-center flex-shrink-0">
 										{rank.season}
 									</div>
 
-									{/* Rank */}
-									<div className="flex items-center gap-1">
+									{/* Rank - Allow this to take remaining space */}
+									<div className="flex items-center gap-1 flex-grow min-w-0">
+										{" "}
+										{/* Added min-w-0 for flex shrink */}
 										{rank.tier ? (
-											<div className="relative w-6 h-6">
+											<div className="relative w-6 h-6 flex-shrink-0">
+												{" "}
+												{/* Added flex-shrink-0 */}
 												<Image
 													src={getRankEmblemPath(rank.tier)}
 													alt={`${rank.tier} emblem`}
@@ -243,12 +250,15 @@ const SeasonRanks = ({
 												/>
 											</div>
 										) : (
-											<div className="w-6 h-6 bg-[--card-bg] rounded-full flex items-center justify-center">
+											<div className="w-6 h-6 bg-[--card-bg] rounded-full flex items-center justify-center flex-shrink-0">
+												{" "}
+												{/* Added flex-shrink-0 */}
 												<span className="text-gray-600 text-xs">-</span>
 											</div>
 										)}
 										<span
-											className={`font-bold text-sm ${getRankColorClass(
+											className={`font-bold text-sm truncate ${getRankColorClass(
+												// Added truncate
 												rank.tier
 											)}`}
 										>
@@ -257,12 +267,19 @@ const SeasonRanks = ({
 									</div>
 								</div>
 
+								{/* Right side: LP - Fixed width for alignment */}
 								{rank.lp !== undefined && rank.lp !== null && (
-									<div className="text-right">
+									<div className="text-right w-[60px] flex-shrink-0">
+										{" "}
+										{/* Fixed width and flex-shrink-0 */}
 										<span className="text-xs text-[--text-secondary]">
 											{rank.lp} LP
 										</span>
 									</div>
+								)}
+								{/* Add a placeholder div if LP is not present to maintain alignment */}
+								{(rank.lp === undefined || rank.lp === null) && (
+									<div className="w-[60px] flex-shrink-0"></div>
 								)}
 							</div>
 						))}

--- a/src/components/tft/Dropdowns.js
+++ b/src/components/tft/Dropdowns.js
@@ -1,12 +1,7 @@
 import React from "react";
-import {
-	FaGlobeAmericas,
-	FaTrophy,
-	FaChevronDown,
-	FaChessKnight,
-} from "react-icons/fa";
+import { FaGlobeAmericas, FaTrophy, FaChevronDown } from "react-icons/fa";
 
-// Region mappings
+// Region mappings (TFT specific, ensure these are correct)
 const regionMappings = {
 	BR1: "Brazil",
 	EUN1: "Europe Nordic & East",
@@ -15,23 +10,20 @@ const regionMappings = {
 	KR: "Korea",
 	LA1: "Latin America North",
 	LA2: "Latin America South",
-	ME1: "Middle East and North Africa",
 	NA1: "North America",
 	OC1: "Oceania",
-	RU: "Russia",
-	SG2: "Singapore",
 	TR1: "Turkey",
-	TW2: "Taiwan",
-	VN2: "Vietnam",
+	RU: "Russia",
+	// Add other TFT regions if needed (e.g., PH2, SG2, TH2, TW2, VN2)
 };
 
-// Tier mappings with colors
+// Tier mappings with colors (TFT specific)
 const tierMappings = {
 	CHALLENGER: { name: "Challenger", color: "text-[--challenger]" },
 	GRANDMASTER: { name: "Grandmaster", color: "text-[--grandmaster]" },
 	MASTER: { name: "Master", color: "text-[--master]" },
 	DIAMOND: { name: "Diamond", color: "text-[--diamond]" },
-	EMERALD: { name: "Emerald", color: "text-[--emerald]" },
+	EMERALD: { name: "Emerald", color: "text-[--emerald]" }, // Emerald exists in TFT?
 	PLATINUM: { name: "Platinum", color: "text-[--platinum]" },
 	GOLD: { name: "Gold", color: "text-[--gold]" },
 	SILVER: { name: "Silver", color: "text-[--silver]" },
@@ -47,7 +39,70 @@ const divisionMappings = {
 	IV: "IV",
 };
 
-const Dropdowns = ({
+// Re-use the CustomSelect component from League Dropdowns
+const CustomSelect = ({
+	label,
+	icon,
+	value,
+	options,
+	onChange,
+	disabled = false,
+}) => {
+	return (
+		<div className="relative">
+			<label className="text-xs text-[--text-secondary] mb-1 block">
+				{label}
+			</label>
+			<div
+				className={`relative bg-[--card-bg] rounded-lg overflow-hidden border border-[--card-border] ${
+					disabled ? "opacity-60" : "hover:border-[--primary]"
+				} transition-colors`}
+			>
+				{/* Custom select header */}
+				<div className="flex items-center gap-2 pr-10 pl-3 py-2">
+					{icon}
+					<select
+						value={value}
+						onChange={onChange}
+						disabled={disabled}
+						className="appearance-none bg-transparent w-full focus:outline-none text-sm cursor-pointer disabled:cursor-not-allowed"
+						style={{
+							colorScheme: "dark",
+							backgroundColor: "var(--card-bg)",
+							color: "var(--text-primary)",
+						}}
+					>
+						{Object.entries(options).map(([key, option]) => {
+							// Handle both simple and complex options
+							const optionValue = key;
+							const optionLabel =
+								typeof option === "object" ? option.name : option;
+							const optionColor =
+								typeof option === "object" ? option.color : "";
+
+							return (
+								<option
+									key={optionValue}
+									value={optionValue}
+									className={optionColor} // Apply color class if available
+								>
+									{optionLabel}
+								</option>
+							);
+						})}
+					</select>
+
+					{/* Dropdown arrow */}
+					<div className="absolute inset-y-0 right-0 flex items-center px-2 pointer-events-none">
+						<FaChevronDown className="text-[--text-secondary]" />
+					</div>
+				</div>
+			</div>
+		</div>
+	);
+};
+
+const TFTDropdowns = ({
 	region,
 	tier,
 	division,
@@ -55,68 +110,23 @@ const Dropdowns = ({
 	setTier,
 	setDivision,
 }) => {
-	// Custom select component to have more styling control
-	const CustomSelect = ({
-		label,
-		icon,
-		value,
-		options,
-		onChange,
-		disabled = false,
-	}) => {
-		return (
-			<div className="relative">
-				<label className="text-xs text-[--text-secondary] mb-1 block">
-					{label}
-				</label>
-				<div
-					className={`relative bg-[--card-bg] rounded-lg overflow-hidden border border-[--card-border] ${
-						disabled ? "opacity-60" : "hover:border-[--tft-primary]"
-					} transition-colors`}
-				>
-					{/* Custom select header */}
-					<div className="flex items-center gap-2 pr-10 pl-3 py-2">
-						{icon}
-						<select
-							value={value}
-							onChange={onChange}
-							disabled={disabled}
-							className="appearance-none bg-transparent w-full focus:outline-none text-sm cursor-pointer disabled:cursor-not-allowed"
-							style={{
-								colorScheme: "dark",
-								backgroundColor: "var(--card-bg)",
-								color: "var(--text-primary)",
-							}}
-						>
-							{Object.entries(options).map(([key, option]) => {
-								// Handle both simple and complex options
-								const optionValue = key;
-								const optionLabel =
-									typeof option === "object" ? option.name : option;
-								const optionColor =
-									typeof option === "object" ? option.color : "";
-
-								return (
-									<option
-										key={optionValue}
-										value={optionValue}
-										className={optionColor}
-									>
-										{optionLabel}
-									</option>
-								);
-							})}
-						</select>
-
-						{/* Dropdown arrow */}
-						<div className="absolute inset-y-0 right-0 flex items-center px-2 pointer-events-none">
-							<FaChevronDown className="text-[--text-secondary]" />
-						</div>
-					</div>
-				</div>
-			</div>
-		);
+	const handleRegionChange = (e) => setRegion(e.target.value);
+	const handleTierChange = (e) => {
+		const newTier = e.target.value;
+		setTier(newTier);
+		// Reset division to 'I' if the new tier is Master or above (no divisions)
+		if (
+			["MASTER", "GRANDMASTER", "CHALLENGER"].includes(newTier.toUpperCase())
+		) {
+			setDivision("I");
+		}
 	};
+	const handleDivisionChange = (e) => setDivision(e.target.value);
+
+	// Determine if division dropdown should be enabled (disabled for Master+)
+	const isDivisionEnabled = !["MASTER", "GRANDMASTER", "CHALLENGER"].includes(
+		tier.toUpperCase()
+	);
 
 	return (
 		<div className="flex flex-col sm:flex-row gap-4">
@@ -126,23 +136,23 @@ const Dropdowns = ({
 				icon={<FaGlobeAmericas className="text-[--text-secondary]" />}
 				value={region}
 				options={regionMappings}
-				onChange={(e) => setRegion(e.target.value)}
+				onChange={handleRegionChange}
 			/>
 
 			{/* Tier Dropdown */}
 			<CustomSelect
 				label="Tier"
 				icon={
-					<FaChessKnight
+					<FaTrophy
 						className={tierMappings[tier]?.color || "text-[--text-secondary]"}
 					/>
 				}
 				value={tier}
 				options={tierMappings}
-				onChange={(e) => setTier(e.target.value)}
+				onChange={handleTierChange}
 			/>
 
-			{/* Division Dropdown */}
+			{/* Division Dropdown (Conditional) */}
 			<CustomSelect
 				label="Division"
 				icon={
@@ -152,11 +162,11 @@ const Dropdowns = ({
 				}
 				value={division}
 				options={divisionMappings}
-				onChange={(e) => setDivision(e.target.value)}
-				disabled={["CHALLENGER", "GRANDMASTER", "MASTER"].includes(tier)}
+				onChange={handleDivisionChange}
+				disabled={!isDivisionEnabled}
 			/>
 		</div>
 	);
 };
 
-export default Dropdowns;
+export default TFTDropdowns;

--- a/src/components/tft/LeaderboardTable.js
+++ b/src/components/tft/LeaderboardTable.js
@@ -3,12 +3,9 @@ import Image from "next/image";
 import Link from "next/link";
 import { FaCrown, FaMedal } from "react-icons/fa";
 
-export default function TFTLeaderboardTable({
-	data,
-	region,
-	tier = "CHALLENGER",
-}) {
-	// Function to get row highlight class based on player rank
+// Re-using the League table structure and styling
+const TFTLeaderboardTable = ({ leaderboardData, region, tier }) => {
+	// Function to get row highlight class based on player rank (identical to League)
 	const getRowHighlightClass = (index) => {
 		if (index === 0)
 			return "bg-gradient-to-r from-yellow-500/20 to-yellow-500/5"; // First place
@@ -17,7 +14,7 @@ export default function TFTLeaderboardTable({
 		return index % 2 === 0 ? "bg-[--card-bg]" : "bg-[--card-bg-secondary]"; // Alternating rows
 	};
 
-	// Function to render rank indicator
+	// Function to render rank indicator (identical to League)
 	const getRankIndicator = (index) => {
 		if (index === 0)
 			return <FaCrown className="text-yellow-500 mr-2" title="1st Place" />;
@@ -28,7 +25,7 @@ export default function TFTLeaderboardTable({
 		return null;
 	};
 
-	// Function to calculate winrate percent and color
+	// Function to calculate winrate percent and color (identical to League)
 	const getWinrateDisplay = (wins, losses) => {
 		const total = wins + losses;
 		if (total === 0) return { percent: "0.0", colorClass: "text-gray-400" };
@@ -48,9 +45,31 @@ export default function TFTLeaderboardTable({
 		};
 	};
 
+	// Get tier color class (using TFT tier names)
+	const getTierColorClass = () => {
+		const lowerTier = tier.toLowerCase();
+		if (
+			[
+				"challenger",
+				"grandmaster",
+				"master",
+				"diamond",
+				"emerald",
+				"platinum",
+				"gold",
+				"silver",
+				"bronze",
+				"iron",
+			].includes(lowerTier)
+		) {
+			return `text-[--${lowerTier}]`;
+		}
+		return "text-[--tft-primary]"; // Fallback
+	};
+
 	return (
 		<div className="w-full overflow-hidden rounded-lg border border-[--card-border] shadow-xl">
-			{/* Table Header */}
+			{/* Table Header (identical to League) */}
 			<div className="w-full bg-[--card-bg-secondary] border-b border-[--card-border] text-xs sm:text-sm text-[--text-secondary] sticky top-0 z-10">
 				<div className="grid grid-cols-12 py-3 px-4">
 					<div className="col-span-1 font-semibold">Rank</div>
@@ -62,41 +81,38 @@ export default function TFTLeaderboardTable({
 
 			{/* Table Body */}
 			<div className="max-h-[600px] overflow-y-auto custom-scrollbar">
-				{data.map((entry, index) => {
-					const winrateInfo = getWinrateDisplay(
-						entry.wins || 0,
-						entry.losses || 0
-					);
-					const gameName = entry.profileData?.gameName || "Unknown";
-					const tagLine = entry.profileData?.tagLine || "Unknown";
+				{leaderboardData.map((entry, index) => {
+					const winrateInfo = getWinrateDisplay(entry.wins, entry.losses);
+					const tierColor = getTierColorClass();
 
 					return (
 						<div
-							key={entry.summonerId || index}
-							className={`grid grid-cols-12 py-3 px-4 items-center border-b border-[--card-border] hover:bg-[--tft-primary]/5 transition-colors duration-150 ${getRowHighlightClass(
+							key={entry.summonerId} // Use summonerId as key
+							className={`grid grid-cols-12 py-3 px-4 items-center border-b border-[--card-border] hover:bg-[--primary]/5 transition-colors duration-150 ${getRowHighlightClass(
 								index
 							)}`}
 						>
-							{/* Rank Column */}
+							{/* Rank Column (identical to League) */}
 							<div className="col-span-1 font-bold flex items-center">
 								{getRankIndicator(index)}
 								{index + 1}
 							</div>
 
-							{/* Summoner Column */}
+							{/* Summoner Column - Adjusted for TFT profile link */}
 							<div className="col-span-5">
 								<Link
 									href={`/tft/profile?gameName=${encodeURIComponent(
-										gameName
+										entry.profileData?.gameName || "Unknown"
 									)}&tagLine=${encodeURIComponent(
-										tagLine
+										entry.profileData?.tagLine || "Unknown"
 									)}&region=${encodeURIComponent(region)}`}
 									className="flex items-center group"
 								>
-									{/* Profile Icon */}
+									{/* Profile Icon (using TFT profileIconId) */}
 									{entry.profileData?.profileIconId ? (
-										<div className="relative w-10 h-10 mr-3 rounded-full overflow-hidden border-2 border-[--card-border] group-hover:border-[--tft-primary] transition-colors">
+										<div className="relative w-10 h-10 mr-3 rounded-full overflow-hidden border-2 border-[--card-border] group-hover:border-[--primary] transition-colors">
 											<Image
+												// Use the correct base URL for TFT profile icons if different, assuming same for now
 												src={`https://raw.communitydragon.org/latest/plugins/rcp-be-lol-game-data/global/default/v1/profile-icons/${entry.profileData.profileIconId}.jpg`}
 												alt="Profile Icon"
 												fill
@@ -109,34 +125,36 @@ export default function TFTLeaderboardTable({
 										</div>
 									)}
 
-									{/* Summoner Name */}
+									{/* Summoner Name (using gameName and tagLine) */}
 									<div className="overflow-hidden">
-										<div className="font-medium text-[--text-primary] truncate group-hover:text-[--tft-primary] transition-colors">
-											{gameName}
+										<div className="font-medium text-[--text-primary] truncate group-hover:text-[--primary] transition-colors">
+											{entry.profileData?.gameName ||
+												entry.summonerName ||
+												"Unknown"}
 										</div>
 										<div className="text-xs text-[--text-secondary]">
-											#{tagLine}
+											#{entry.profileData?.tagLine || "Unknown"}
 										</div>
 									</div>
 								</Link>
 							</div>
 
-							{/* LP Column */}
+							{/* LP Column (using tier color) */}
 							<div className="col-span-2 text-center">
-								<span className={`font-bold text-[--${tier.toLowerCase()}]`}>
+								<span className={`font-bold ${tierColor}`}>
 									{entry.leaguePoints}
 								</span>
 								<span className="text-[--text-secondary] ml-1 text-sm">LP</span>
 							</div>
 
-							{/* Win Rate Column */}
+							{/* Win Rate Column (identical to League) */}
 							<div className="col-span-4">
 								<div className="flex flex-col sm:flex-row items-center justify-center gap-2">
 									{/* Win/Loss */}
 									<div className="text-sm whitespace-nowrap">
-										<span className="text-[--success]">{entry.wins || 0}W</span>
+										<span className="text-[--success]">{entry.wins}W</span>
 										<span className="text-[--text-secondary] mx-1">/</span>
-										<span className="text-[--error]">{entry.losses || 0}L</span>
+										<span className="text-[--error]">{entry.losses}L</span>
 									</div>
 
 									{/* Win Rate Bar */}
@@ -159,4 +177,6 @@ export default function TFTLeaderboardTable({
 			</div>
 		</div>
 	);
-}
+};
+
+export default TFTLeaderboardTable;


### PR DESCRIPTION
This pull request includes updates to improve the Teamfight Tactics (TFT) leaderboard functionality, enhance user experience, and ensure consistency in environment variable usage. The most significant changes involve refactoring the TFT leaderboard API and frontend, aligning environment variable syntax in the `Dockerfile`, and improving UI components for better alignment and responsiveness.

### Backend Changes:
* **TFT Leaderboard API Enhancements**:
  - Improved error handling for missing API keys, rate limits, and unexpected responses. Added retries with delays for API requests. [[1]](diffhunk://#diff-9790d991f20a5a1b5f2bdfb278ec2bf3edbeeb4d8fbd29f24f9456dd54d8ef62L13-R83) [[2]](diffhunk://#diff-9790d991f20a5a1b5f2bdfb278ec2bf3edbeeb4d8fbd29f24f9456dd54d8ef62L57-R161)
  - Enriched leaderboard data with profile details (game name, tag line, and profile icon) using Riot API endpoints.

### Frontend Changes:
* **TFT Leaderboard Page Refactor**:
  - Converted the leaderboard page to a client component, added error handling, retry logic, and a loading state. Introduced filters for region, tier, and division using dropdowns.
  - Updated UI to dynamically adjust styles based on the selected tier, improving visual clarity.

* **Season Ranks Component Improvements**:
  - Enhanced alignment and responsiveness of rank history items by adding fixed widths and flexbox properties. [[1]](diffhunk://#diff-299f1f111447a9fec1eeafea12acccd9572b58b1f1ff1af80f8f2db07644d186L225-R243) [[2]](diffhunk://#diff-299f1f111447a9fec1eeafea12acccd9572b58b1f1ff1af80f8f2db07644d186R270-R283)

### Environment Configuration:
* **Environment Variable Syntax Standardization**:
  - Updated `Dockerfile` to use consistent `KEY=VALUE` syntax for environment variables, improving compatibility and readability. [[1]](diffhunk://#diff-dd2c0eb6ea5cfc6c4bd4eac30934e2d5746747af48fef6da689e85b752f39557L18-R18) [[2]](diffhunk://#diff-dd2c0eb6ea5cfc6c4bd4eac30934e2d5746747af48fef6da689e85b752f39557L27-R28) [[3]](diffhunk://#diff-dd2c0eb6ea5cfc6c4bd4eac30934e2d5746747af48fef6da689e85b752f39557L47-R48)