### PR TITLE
feat(leagueApi): remove unused rank calculation and fetch participant rank logic

### DIFF
--- a/src/components/league/MatchHistory.js
+++ b/src/components/league/MatchHistory.js
@@ -341,6 +341,7 @@ const getGradientBackground = (match, currentPlayer, isRemake, isMVP) => {
     : "bg-gradient-to-r from-[--card-bg] via-red-900/20 to-[--card-bg] border border-[--card-border]";
 };
 
+// Helper to normalize team position values
 const normaliseTeamPosition = (position) => {
   if (!position) return "";
   switch (position.toUpperCase()) {
@@ -360,89 +361,6 @@ const normaliseTeamPosition = (position) => {
     default:
       return position.toUpperCase();
   }
-};
-
-// Calculate average rank for a match
-const calculateAverageRank = (participants) => {
-  // Check if participants have rank data
-  const hasRankData = participants.some((p) => p.rank);
-  if (!hasRankData) return null;
-
-  // Define rank tiers and their numeric values
-  const rankTiers = {
-    IRON: 0,
-    BRONZE: 1,
-    SILVER: 2,
-    GOLD: 3,
-    PLATINUM: 4,
-    EMERALD: 5,
-    DIAMOND: 6,
-    MASTER: 7,
-    GRANDMASTER: 8,
-    CHALLENGER: 9,
-  };
-
-  // Define rank divisions and their numeric values
-  const rankDivisions = {
-    IV: 0,
-    III: 1,
-    II: 2,
-    I: 3,
-  };
-
-  // Filter out participants without rank data or with "Unranked"
-  const rankedParticipants = participants.filter(
-    (p) => p.rank && p.rank.toLowerCase() !== "unranked",
-  );
-
-  if (rankedParticipants.length === 0) return "Unranked";
-
-  // Calculate average numeric rank
-  let totalRankValue = 0;
-
-  rankedParticipants.forEach((p) => {
-    const rankParts = p.rank.split(" ");
-    const tier = rankParts[0].toUpperCase();
-    const division = rankParts[1] || "I";
-
-    // Calculate numeric value for this rank
-    const tierValue = rankTiers[tier] || 0;
-    const divisionValue = rankDivisions[division] || 0;
-
-    // Higher tiers (like Diamond) have higher values
-    totalRankValue += tierValue * 4 + divisionValue;
-  });
-
-  const averageRankValue = totalRankValue / rankedParticipants.length;
-
-  // Convert back to tier and division
-  const averageTierValue = Math.floor(averageRankValue / 4);
-  const averageDivisionValue = Math.round(averageRankValue % 4);
-
-  // Get tier name from value
-  let averageTier = "Unranked";
-  for (const [tier, value] of Object.entries(rankTiers)) {
-    if (value === averageTierValue) {
-      averageTier = tier.charAt(0) + tier.slice(1).toLowerCase();
-      break;
-    }
-  }
-
-  // Get division name from value
-  let averageDivision = "IV";
-  for (const [division, value] of Object.entries(rankDivisions)) {
-    if (value === averageDivisionValue) {
-      averageDivision = division;
-      break;
-    }
-  }
-
-  // For Master+ tiers, don't show division
-  if (averageTierValue >= 7) {
-    return averageTier;
-  }
-
-  return `${averageTier} ${averageDivision}`;
 };
 
 const MatchHistory = ({
@@ -900,46 +818,6 @@ const MatchHistory = ({
                               )}
                           </p>
                           <p>• </p>
-                          {/* Average Rank Display */}
-                          {match.info.queueId !== 1700 &&
-                            match.info.queueId !== 1710 && (
-                              <p className="text-sm flex items-center mt-1">
-                                {(() => {
-                                  const avgRank =
-                                    calculateAverageRank(participants);
-                                  if (!avgRank) return null;
-
-                                  const shortRank =
-                                    avgRank.toLowerCase() !== "unranked"
-                                      ? avgRank.split(" ")[0].toLowerCase()
-                                      : null;
-
-                                  return (
-                                    <>
-                                      {shortRank && (
-                                        <div className="relative w-4 h-4 mr-1 flex-shrink-0">
-                                          <Image
-                                            src={`/images/league/rankedEmblems/${shortRank}.webp`}
-                                            alt=""
-                                            fill
-                                            className="object-contain"
-                                          />
-                                        </div>
-                                      )}
-                                      <span
-                                        className={
-                                          shortRank
-                                            ? "text-[--primary]"
-                                            : "text-[--text-secondary]"
-                                        }
-                                      >
-                                        {avgRank}
-                                      </span>
-                                    </>
-                                  );
-                                })()}
-                              </p>
-                            )}
                         </div>
                         <div className="flex">
                           <div className="flex flex-col justify-center mr-8">

--- a/src/components/league/MatchStatsTab.js
+++ b/src/components/league/MatchStatsTab.js
@@ -503,8 +503,7 @@ function Participant({ p, puuid, r, getA, getPerk, arena = false }) {
 							<span className="text-[--text-secondary] text-xs">
 								#{p.riotIdTagline}
 							</span>
-						</div>
-						<div className="text-xs text-[--text-secondary] flex items-center">
+						</div>						<div className="text-xs text-[--text-secondary] flex items-center">
 							{/* Position icon if available */}
 							{p.individualPosition &&
 								p.individualPosition !== "Invalid" &&
@@ -519,25 +518,6 @@ function Participant({ p, puuid, r, getA, getPerk, arena = false }) {
 								)}
 							<span>Level {p.summonerLevel}</span>
 						</div>
-
-						{/* Rank information if available */}
-						{p.rank && (
-							<div className="text-xs flex items-center mt-1">
-								{p.rank.toLowerCase() !== "unranked" && (
-									<div className="relative w-4 h-4 mr-1 flex-shrink-0">
-										<NextImage
-											src={`/images/league/rankedEmblems/${p.rank.split(" ")[0].toLowerCase()}.webp`}
-											alt=""
-											fill
-											className="object-contain"
-										/>
-									</div>
-								)}
-								<span className={`${p.rank.toLowerCase() !== "unranked" ? "text-[--primary]" : "text-[--text-secondary]"}`}>
- 									{p.rank} {p.rank.toLowerCase() !== "unranked" && p.lp && `${p.lp} LP`}
-								</span>
-							</div>
-						)}
 					</div>
 				</div>
 


### PR DESCRIPTION
This pull request removes rank-related features from the League Match History and Match Stats components, as well as the backend logic for fetching and processing rank data. The changes simplify the codebase by eliminating unnecessary rank calculations and API calls.

### Frontend Changes:
* Removed the `calculateAverageRank` function and its usage in `MatchHistory.js`, along with the display logic for average rank in match history. [[1]](diffhunk://#diff-dc4ba1319a22fd44b1dc89425f71add01e214115c7f9b7d23703ac01cb155b8fL365-L447) [[2]](diffhunk://#diff-dc4ba1319a22fd44b1dc89425f71add01e214115c7f9b7d23703ac01cb155b8fL903-L942)
* Removed rank display logic for individual participants in `MatchStatsTab.js`, including rank icons and LP information.

### Backend Changes:
* Removed logic for enriching match participant data with rank information in `leagueApi.js`, including the `fetchParticipantRank` function and its retry mechanism. [[1]](diffhunk://#diff-883b0ea11e5808f4715685d8a762191e1a85bd1b83eedd624852c43df272f5c8L95-R95) [[2]](diffhunk://#diff-883b0ea11e5808f4715685d8a762191e1a85bd1b83eedd624852c43df272f5c8L214-L318)

These changes streamline the application by focusing on core functionality and reducing reliance on external rank data.