### PR TITLE
fix(page): update external links to point to the new YouTrack dashboard

### DIFF
--- a/src/app/legal/support/page.js
+++ b/src/app/legal/support/page.js
@@ -54,7 +54,7 @@ const Support = () => {
               </p>
             </div>
             <a
-              href="https://danblock97.atlassian.net/jira/software/c/form/ebdfca4d-9732-4107-8501-b77f21d0bfc5"
+              href="https://danblock97.youtrack.cloud/dashboard?id=214-1"
               target="_blank"
               rel="noopener noreferrer"
               className="w-full mt-auto text-center px-6 py-3 bg-gradient-to-r from-red-600 to-pink-600 hover:from-red-700 hover:to-pink-700 text-white font-semibold rounded-md transition-colors duration-300 text-lg block"
@@ -95,7 +95,7 @@ const Support = () => {
               </p>
             </div>
             <a
-              href="https://danblock97.atlassian.net/jira/software/c/form/8f775bab-146f-4849-8fce-8d39c2a8280f"
+              href="https://danblock97.youtrack.cloud/dashboard?id=214-1"
               target="_blank"
               rel="noopener noreferrer"
               className="w-full mt-auto text-center px-6 py-3 bg-gradient-to-r from-green-600 to-teal-600 hover:from-green-700 hover:to-teal-700 text-white font-semibold rounded-md transition-colors duration-300 text-lg block"


### PR DESCRIPTION
This pull request updates the support links in the `Support` component to point to a new issue tracking system. Previously, the links directed users to Jira forms, but they now redirect to YouTrack dashboards.

### Updates to support links:

* [`src/app/legal/support/page.js`](diffhunk://#diff-e9c202eca971f16597ff2427ab96936e82696949d9971ea7dd7bb85210c5b7b8L57-R57): Updated two `href` attributes in the `Support` component to change the destination from Jira forms to YouTrack dashboards. [[1]](diffhunk://#diff-e9c202eca971f16597ff2427ab96936e82696949d9971ea7dd7bb85210c5b7b8L57-R57) [[2]](diffhunk://#diff-e9c202eca971f16597ff2427ab96936e82696949d9971ea7dd7bb85210c5b7b8L98-R98)